### PR TITLE
Feat/fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,21 +255,8 @@ sites:
         text: "Kaputt, versuch es später nochmal."
 ````
 
-`unavailableResponse` applies to upstream `503`, `errorResponse` to upstream `500`. Each slot is
-one of:
-
-- page: `text` (plain body) and/or `file` with an optional `contentType` (default `text/html; charset=UTF-8`). If
-  both `file` and `text` are set, `file` wins; if the file can't be read, `text` is used instead.
-- redirect: `location` (optionally with `status`, defaults to `302`), or the shorthand
-  `permanentRedirect` (always `308`) / `temporaryRedirect` (always `307`)
-
-You can't mix page fields (`text`/`file`) with redirect fields (`location`/`permanentRedirect`/
-`temporaryRedirect`)
-
-Configuration is layered, `built-in defaults > global fallback > site fallback`, merging happens **per
-slot, as a whole object**, not per field: if a site sets `unavailableResponse`, that entire slot
-(including any inherited `file`/`contentType`) is replaced by what the site specified, while an
-`errorResponse` the site doesn't mention keeps inheriting from global or default config.
+See `FallbackConfig` and `ResponseConfig` for the slot semantics, the page/redirect shape, and how
+global and per-site config is layered.
 
 ## Local testing
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,43 @@ Example Paypal
 - IP: 173.0.81.140
 
 
+## Fallback / maintenance pages
+
+If the upstream returns `503` or `500`, or the streamed response head arrives with one of those
+statuses, Sensepitch Edge can serve a page or redirect instead of forwarding the upstream error.
+This is configured under `fallback:`, either globally or per site:
+
+````yaml
+fallback:
+  unavailableResponse:
+    file: /etc/sensepitch/unavailable.html
+    contentType: text/html; charset=UTF-8
+  errorResponse:
+    text: "Something is broken, please try again later"
+sites:
+  www.example.com:
+  www.example.de:
+    fallback:
+      unavailableResponse:
+        text: "Kaputt, versuch es später nochmal."
+````
+
+`unavailableResponse` applies to upstream `503`, `errorResponse` to upstream `500`. Each slot is
+one of:
+
+- page: `text` (plain body) and/or `file` with an optional `contentType` (default `text/html; charset=UTF-8`). If
+  both `file` and `text` are set, `file` wins; if the file can't be read, `text` is used instead.
+- redirect: `location` (optionally with `status`, defaults to `302`), or the shorthand
+  `permanentRedirect` (always `308`) / `temporaryRedirect` (always `307`)
+
+You can't mix page fields (`text`/`file`) with redirect fields (`location`/`permanentRedirect`/
+`temporaryRedirect`)
+
+Configuration is layered, `built-in defaults > global fallback > site fallback`, merging happens **per
+slot, as a whole object**, not per field: if a site sets `unavailableResponse`, that entire slot
+(including any inherited `file`/`contentType`) is replaced by what the site specified, while an
+`errorResponse` the site doesn't mention keeps inheriting from global or default config.
+
 ## Local testing
 
 ````

--- a/src/main/java/org/sensepitch/edge/DeflectorHandler.java
+++ b/src/main/java/org/sensepitch/edge/DeflectorHandler.java
@@ -34,21 +34,21 @@ public class DeflectorHandler implements ProtectionPlugin {
       // this is just for progress reporting and debugging
       request.headers().set(Deflector.TRAFFIC_FLAVOR_HEADER, Deflector.FLAVOR_DEFLECT);
       FullHttpResponse response =
-        new DefaultFullHttpResponse(
-          HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT, Unpooled.EMPTY_BUFFER);
+          new DefaultFullHttpResponse(
+              HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT, Unpooled.EMPTY_BUFFER);
       // Prevent caching
       response
-        .headers()
-        .set(HttpHeaderNames.CACHE_CONTROL, "no-store, no-cache, must-revalidate, max-age=0");
+          .headers()
+          .set(HttpHeaderNames.CACHE_CONTROL, "no-store, no-cache, must-revalidate, max-age=0");
       response.headers().set(HttpHeaderNames.PRAGMA, "no-cache");
       response.headers().set(HttpHeaderNames.EXPIRES, "0");
       ctx.writeAndFlush(response);
     } else if (request.method() == HttpMethod.GET
-      && request.uri().startsWith(Deflector.CHALLENGE_RESOURCES_URL)) {
+        && request.uri().startsWith(Deflector.CHALLENGE_RESOURCES_URL)) {
       request.headers().set(Deflector.TRAFFIC_FLAVOR_HEADER, Deflector.FLAVOR_DEFLECT);
       deflector.outputChallengeResources(ctx, request);
     } else if (request.method() == HttpMethod.GET
-      && request.uri().startsWith(Deflector.CHALLENGE_ANSWER_URL)) {
+        && request.uri().startsWith(Deflector.CHALLENGE_ANSWER_URL)) {
       request.headers().set(Deflector.TRAFFIC_FLAVOR_HEADER, Deflector.FLAVOR_USER);
       deflector.handleChallengeAnswer(ctx, request);
     } else {

--- a/src/main/java/org/sensepitch/edge/Fallback.java
+++ b/src/main/java/org/sensepitch/edge/Fallback.java
@@ -1,6 +1,5 @@
 package org.sensepitch.edge;
 
-import io.netty.channel.ChannelHandler;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/main/java/org/sensepitch/edge/Fallback.java
+++ b/src/main/java/org/sensepitch/edge/Fallback.java
@@ -18,6 +18,14 @@ import java.nio.file.Path;
  */
 public class Fallback {
 
+  /**
+   * A resolved redirect.
+   *
+   * @param status 3xx status code
+   * @param location target URL for the {@code Location} header
+   */
+  public record Redirect(int status, String location) {}
+
   private static final String CLASSPATH_PREFIX = "classpath:";
 
   private static final String FILE_PREFIX = "file:";
@@ -52,7 +60,7 @@ public class Fallback {
    *     text} (an empty page config)
    */
   private static byte[] pageBody(ResponseConfig cfg) {
-    if (cfg.resolvedRedirect() != null) {
+    if (resolvedRedirect(cfg.location(), cfg.status()) != null) {
       return null;
     }
     if (cfg.file() != null) {
@@ -105,5 +113,10 @@ public class Fallback {
       throw new FileNotFoundException("Classpath resource not found: " + path);
     }
     return in;
+  }
+
+  public static Redirect resolvedRedirect(String location, int status) {
+    if (location != null) return new Redirect(status, location);
+    return null;
   }
 }

--- a/src/main/java/org/sensepitch/edge/Fallback.java
+++ b/src/main/java/org/sensepitch/edge/Fallback.java
@@ -1,0 +1,109 @@
+package org.sensepitch.edge;
+
+import io.netty.channel.ChannelHandler;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Builds fallback handlers from config. The configured page bodies are read once, at construction,
+ * and shared by every handler.
+ *
+ * @author Raid Thabet
+ */
+public class Fallback {
+
+  private static final String CLASSPATH_PREFIX = "classpath:";
+
+  private static final String FILE_PREFIX = "file:";
+
+  private final FallbackConfig config;
+
+  private final byte[] unavailableContent;
+
+  private final byte[] errorContent;
+
+  /**
+   * @throws IllegalArgumentException if a page response has neither {@code file} nor {@code text}
+   * @throws UncheckedIOException if a configured page resource cannot be read
+   */
+  public Fallback(FallbackConfig config) {
+    this.config = config;
+    this.unavailableContent = pageBody(config.unavailableResponse());
+    this.errorContent = pageBody(config.errorResponse());
+  }
+
+  public FallbackHandler newHandler() {
+    return new FallbackHandler(config, unavailableContent, errorContent);
+  }
+
+  /**
+   * Build the body of the page {@code cfg} describes: the resource named by {@link
+   * ResponseConfig#file()} (see {@link #openResource} for how the location is resolved), or else
+   * the inline {@link ResponseConfig#text()} as UTF-8. Returns {@code null} for a redirect, which
+   * has no body. {@link ResponseConfig} already rejects setting both {@code file} and {@code text}.
+   *
+   * @throws IllegalArgumentException if a page {@code cfg} has neither {@code file} nor {@code
+   *     text} (an empty page config)
+   */
+  private static byte[] pageBody(ResponseConfig cfg) {
+    if (cfg.resolvedRedirect() != null) {
+      return null;
+    }
+    if (cfg.file() != null) {
+      return readResource(cfg.file());
+    }
+    if (cfg.text() != null) {
+      return cfg.text().getBytes(StandardCharsets.UTF_8);
+    }
+    throw new IllegalArgumentException("page config has neither file nor text");
+  }
+
+  /**
+   * Read the resource fully; an unresolvable location is a configuration error that fails
+   * construction.
+   */
+  private static byte[] readResource(String file) {
+    try (InputStream in = openResource(file)) {
+      return in.readAllBytes();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read fallback page: " + file, e);
+    }
+  }
+
+  /**
+   * Open the resource named by {@code location}. An explicit {@code classpath:} or {@code file:}
+   * scheme picks exactly that source; a bare (schemeless) location is tried on the filesystem first
+   * and then on the classpath.
+   */
+  private static InputStream openResource(String location) throws IOException {
+    if (location.startsWith(CLASSPATH_PREFIX)) {
+      return openClasspath(location.substring(CLASSPATH_PREFIX.length()));
+    }
+    if (location.startsWith(FILE_PREFIX)) {
+      return new FileInputStream(location.substring(FILE_PREFIX.length()));
+    }
+    // No scheme: try the filesystem first, then the classpath.
+    Path filePath = Path.of(location);
+    if (Files.isReadable(filePath)) {
+      return Files.newInputStream(filePath);
+    }
+    return openClasspath(location);
+  }
+
+  private static InputStream openClasspath(String path) throws IOException {
+    if (path.startsWith("/")) {
+      path = path.substring(1);
+    }
+    InputStream in = Fallback.class.getClassLoader().getResourceAsStream(path);
+    if (in == null) {
+      throw new FileNotFoundException("Classpath resource not found: " + path);
+    }
+    return in;
+  }
+}

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -1,0 +1,27 @@
+package org.sensepitch.edge;
+
+import lombok.Builder;
+
+/**
+ * @author Raid Thabet
+*/
+@Builder(toBuilder = true)
+public record FallbackConfig(
+        String pathToUnavailablePage,
+        String unavailableText,
+        String pathToErrorPage,
+        String errorText
+) {
+    public static final String DEFAULT_PATH_TO_UNAVAILABLE_PAGE = "/unavailable.html";
+    public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
+    public static final String DEFAULT_PATH_TO_ERROR_PAGE = "/error.html";
+    public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
+
+    public static final FallbackConfig DEFAULT =
+            FallbackConfig.builder()
+                    .pathToUnavailablePage(DEFAULT_PATH_TO_UNAVAILABLE_PAGE)
+                    .unavailableText(DEFAULT_UNAVAILABLE_TEXT)
+                    .pathToErrorPage(DEFAULT_PATH_TO_ERROR_PAGE)
+                    .errorText(DEFAULT_ERROR_TEXT)
+                    .build();
+}

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -3,6 +3,18 @@ package org.sensepitch.edge;
 import lombok.Builder;
 
 /**
+ * What the edge sends instead of an upstream 5xx. Each response is either a page (inline {@code
+ * text} or a {@code file} resource) or a redirect ({@code location}), see {@link ResponseConfig}.
+ * Unset responses fall back to {@link #DEFAULTS} via {@link #merge}.
+ *
+ * <p>Configuration is layered, {@code built-in defaults > global fallback > site fallback}. Merging
+ * happens <b>per slot, as a whole object</b>, not per field: if a site sets {@code
+ * unavailableResponse}, that entire slot (including any inherited {@code file}/{@code contentType})
+ * is replaced by what the site specified, while an {@code errorResponse} the site doesn't mention
+ * keeps inheriting from global or default config.
+ *
+ * @param unavailableResponse replaces an upstream 503, i.e. the site is reachable but not serving
+ * @param errorResponse replaces an upstream 500, i.e. the site failed on the request
  * @author Raid Thabet
  */
 @Builder(toBuilder = true)

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -17,7 +17,7 @@ public record FallbackConfig(
     public static final String DEFAULT_ERROR_PAGE = "fallback/error.html";
     public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
 
-    public static final FallbackConfig DEFAULT =
+    public static final FallbackConfig DEFAULTS =
             FallbackConfig.builder()
                     .unavailablePage(DEFAULT_UNAVAILABLE_PAGE)
                     .unavailableText(DEFAULT_UNAVAILABLE_TEXT)

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -7,21 +7,21 @@ import lombok.Builder;
 */
 @Builder(toBuilder = true)
 public record FallbackConfig(
-        String pathToUnavailablePage,
+        String unavailablePage,
         String unavailableText,
-        String pathToErrorPage,
+        String errorPage,
         String errorText
 ) {
-    public static final String DEFAULT_PATH_TO_UNAVAILABLE_PAGE = "/unavailable.html";
+    public static final String DEFAULT_UNAVAILABLE_PAGE = "/unavailable.html";
     public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
-    public static final String DEFAULT_PATH_TO_ERROR_PAGE = "/error.html";
+    public static final String DEFAULT_ERROR_PAGE = "/error.html";
     public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
 
     public static final FallbackConfig DEFAULT =
             FallbackConfig.builder()
-                    .pathToUnavailablePage(DEFAULT_PATH_TO_UNAVAILABLE_PAGE)
+                    .unavailablePage(DEFAULT_UNAVAILABLE_PAGE)
                     .unavailableText(DEFAULT_UNAVAILABLE_TEXT)
-                    .pathToErrorPage(DEFAULT_PATH_TO_ERROR_PAGE)
+                    .errorPage(DEFAULT_ERROR_PAGE)
                     .errorText(DEFAULT_ERROR_TEXT)
                     .build();
 }

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -8,9 +8,7 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record FallbackConfig(ResponseConfig unavailableResponse, ResponseConfig errorResponse) {
   public static final String DEFAULT_UNAVAILABLE_FILE = "classpath:fallback/unavailable.html";
-  public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
   public static final String DEFAULT_ERROR_FILE = "classpath:fallback/error.html";
-  public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
   public static final String DEFAULT_CONTENT_TYPE = "text/html; charset=UTF-8";
 
   public static final FallbackConfig DEFAULTS =

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -12,9 +12,9 @@ public record FallbackConfig(
         String errorPage,
         String errorText
 ) {
-    public static final String DEFAULT_UNAVAILABLE_PAGE = "/unavailable.html";
+    public static final String DEFAULT_UNAVAILABLE_PAGE = "fallback/unavailable.html";
     public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
-    public static final String DEFAULT_ERROR_PAGE = "/error.html";
+    public static final String DEFAULT_ERROR_PAGE = "fallback/error.html";
     public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
 
     public static final FallbackConfig DEFAULT =

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -6,39 +6,35 @@ import lombok.Builder;
  * @author Raid Thabet
  */
 @Builder(toBuilder = true)
-public record FallbackConfig(
-        ResponseConfig unavailableResponse,
-        ResponseConfig errorResponse
-) {
-    public static final String DEFAULT_UNAVAILABLE_FILE = "fallback/unavailable.html";
-    public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
-    public static final String DEFAULT_ERROR_FILE = "fallback/error.html";
-    public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
-    public static final String DEFAULT_CONTENT_TYPE = "text/html; charset=UTF-8";
+public record FallbackConfig(ResponseConfig unavailableResponse, ResponseConfig errorResponse) {
+  public static final String DEFAULT_UNAVAILABLE_FILE = "fallback/unavailable.html";
+  public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
+  public static final String DEFAULT_ERROR_FILE = "fallback/error.html";
+  public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
+  public static final String DEFAULT_CONTENT_TYPE = "text/html; charset=UTF-8";
 
-    public static final FallbackConfig DEFAULTS =
-            FallbackConfig.builder()
-                    .unavailableResponse(
-                            ResponseConfig.builder()
-                                    .file(DEFAULT_UNAVAILABLE_FILE)
-                                    .text(DEFAULT_UNAVAILABLE_TEXT)
-                                    .contentType(DEFAULT_CONTENT_TYPE)
-                                    .build()
-                    )
-                    .errorResponse(
-                            ResponseConfig.builder()
-                                    .file(DEFAULT_ERROR_FILE)
-                                    .text(DEFAULT_ERROR_TEXT)
-                                    .contentType(DEFAULT_CONTENT_TYPE)
-                                    .build()
-                    )
-                    .build();
+  public static final FallbackConfig DEFAULTS =
+      FallbackConfig.builder()
+          .unavailableResponse(
+              ResponseConfig.builder()
+                  .file(DEFAULT_UNAVAILABLE_FILE)
+                  .text(DEFAULT_UNAVAILABLE_TEXT)
+                  .contentType(DEFAULT_CONTENT_TYPE)
+                  .build())
+          .errorResponse(
+              ResponseConfig.builder()
+                  .file(DEFAULT_ERROR_FILE)
+                  .text(DEFAULT_ERROR_TEXT)
+                  .contentType(DEFAULT_CONTENT_TYPE)
+                  .build())
+          .build();
 
-    public FallbackConfig merge(FallbackConfig o) {
-        if (o == null) return this;
-        return FallbackConfig.builder()
-                .unavailableResponse(o.unavailableResponse != null ? o.unavailableResponse : unavailableResponse)
-                .errorResponse(o.errorResponse != null ? o.errorResponse : errorResponse)
-                .build();
-    }
+  public FallbackConfig merge(FallbackConfig o) {
+    if (o == null) return this;
+    return FallbackConfig.builder()
+        .unavailableResponse(
+            o.unavailableResponse != null ? o.unavailableResponse : unavailableResponse)
+        .errorResponse(o.errorResponse != null ? o.errorResponse : errorResponse)
+        .build();
+  }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -7,9 +7,9 @@ import lombok.Builder;
  */
 @Builder(toBuilder = true)
 public record FallbackConfig(ResponseConfig unavailableResponse, ResponseConfig errorResponse) {
-  public static final String DEFAULT_UNAVAILABLE_FILE = "fallback/unavailable.html";
+  public static final String DEFAULT_UNAVAILABLE_FILE = "classpath:fallback/unavailable.html";
   public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
-  public static final String DEFAULT_ERROR_FILE = "fallback/error.html";
+  public static final String DEFAULT_ERROR_FILE = "classpath:fallback/error.html";
   public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
   public static final String DEFAULT_CONTENT_TYPE = "text/html; charset=UTF-8";
 
@@ -18,13 +18,11 @@ public record FallbackConfig(ResponseConfig unavailableResponse, ResponseConfig 
           .unavailableResponse(
               ResponseConfig.builder()
                   .file(DEFAULT_UNAVAILABLE_FILE)
-                  .text(DEFAULT_UNAVAILABLE_TEXT)
                   .contentType(DEFAULT_CONTENT_TYPE)
                   .build())
           .errorResponse(
               ResponseConfig.builder()
                   .file(DEFAULT_ERROR_FILE)
-                  .text(DEFAULT_ERROR_TEXT)
                   .contentType(DEFAULT_CONTENT_TYPE)
                   .build())
           .build();

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -7,31 +7,38 @@ import lombok.Builder;
  */
 @Builder(toBuilder = true)
 public record FallbackConfig(
-        String unavailablePage,
-        String unavailableText,
-        String errorPage,
-        String errorText
+        ResponseConfig unavailableResponse,
+        ResponseConfig errorResponse
 ) {
-    public static final String DEFAULT_UNAVAILABLE_PAGE = "fallback/unavailable.html";
+    public static final String DEFAULT_UNAVAILABLE_FILE = "fallback/unavailable.html";
     public static final String DEFAULT_UNAVAILABLE_TEXT = "Service Unavailable";
-    public static final String DEFAULT_ERROR_PAGE = "fallback/error.html";
+    public static final String DEFAULT_ERROR_FILE = "fallback/error.html";
     public static final String DEFAULT_ERROR_TEXT = "Internal Server Error";
+    public static final String DEFAULT_CONTENT_TYPE = "text/html; charset=UTF-8";
 
     public static final FallbackConfig DEFAULTS =
             FallbackConfig.builder()
-                    .unavailablePage(DEFAULT_UNAVAILABLE_PAGE)
-                    .unavailableText(DEFAULT_UNAVAILABLE_TEXT)
-                    .errorPage(DEFAULT_ERROR_PAGE)
-                    .errorText(DEFAULT_ERROR_TEXT)
+                    .unavailableResponse(
+                            ResponseConfig.builder()
+                                    .file(DEFAULT_UNAVAILABLE_FILE)
+                                    .text(DEFAULT_UNAVAILABLE_TEXT)
+                                    .contentType(DEFAULT_CONTENT_TYPE)
+                                    .build()
+                    )
+                    .errorResponse(
+                            ResponseConfig.builder()
+                                    .file(DEFAULT_ERROR_FILE)
+                                    .text(DEFAULT_ERROR_TEXT)
+                                    .contentType(DEFAULT_CONTENT_TYPE)
+                                    .build()
+                    )
                     .build();
 
     public FallbackConfig merge(FallbackConfig o) {
         if (o == null) return this;
         return FallbackConfig.builder()
-                .unavailablePage(o.unavailablePage() != null ? o.unavailablePage() : unavailablePage)
-                .unavailableText(o.unavailableText() != null ? o.unavailableText() : unavailableText)
-                .errorPage(o.errorPage() != null ? o.errorPage() : errorPage)
-                .errorText(o.errorText() != null ? o.errorText() : errorText)
+                .unavailableResponse(o.unavailableResponse != null ? o.unavailableResponse : unavailableResponse)
+                .errorResponse(o.errorResponse != null ? o.errorResponse : errorResponse)
                 .build();
     }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackConfig.java
+++ b/src/main/java/org/sensepitch/edge/FallbackConfig.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 /**
  * @author Raid Thabet
-*/
+ */
 @Builder(toBuilder = true)
 public record FallbackConfig(
         String unavailablePage,
@@ -24,4 +24,14 @@ public record FallbackConfig(
                     .errorPage(DEFAULT_ERROR_PAGE)
                     .errorText(DEFAULT_ERROR_TEXT)
                     .build();
+
+    public FallbackConfig merge(FallbackConfig o) {
+        if (o == null) return this;
+        return FallbackConfig.builder()
+                .unavailablePage(o.unavailablePage() != null ? o.unavailablePage() : unavailablePage)
+                .unavailableText(o.unavailableText() != null ? o.unavailableText() : unavailableText)
+                .errorPage(o.errorPage() != null ? o.errorPage() : errorPage)
+                .errorText(o.errorText() != null ? o.errorText() : errorText)
+                .build();
+    }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -4,9 +4,9 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.*;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 
 import java.io.IOException;
@@ -15,10 +15,25 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+/**
+ * Replaces upstream 500/503 responses with an operator-configured fallback page (or text). Handles
+ * both the aggregated {@link FullHttpResponse} (stub upstream) and the streamed form a real backend
+ * produces ({@link HttpResponse} head + {@link HttpContent} chunks + {@link LastHttpContent}).
+ *
+ * @author Raid Thabet
+ */
 @ChannelHandler.Sharable
 public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
     static ProxyLogger LOG = ProxyLogger.get(FallbackHandler.class);
+
+    /**
+     * Per-connection flag: {@code TRUE} while the origin body chunks of a streamed 5xx response are
+     * being dropped after its head was replaced with the fallback. Stored on the channel (not as an
+     * instance field) so the handler can remain {@link ChannelHandler.Sharable @Sharable}.
+     */
+    private static final AttributeKey<Boolean> SUPPRESSING =
+            AttributeKey.valueOf(FallbackHandler.class, "suppressing");
 
     private final byte[] unavailableContent;
 
@@ -31,30 +46,69 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (msg instanceof FullHttpResponse response) {
-            int status = response.status().code();
-            if (status == 503 || status == 500) {
-                byte[] content = (status == 503) ? unavailableContent : errorContent;
-                FullHttpResponse fallbackResponse = new DefaultFullHttpResponse(
-                        response.protocolVersion(),
-                        response.status(),
-                        ctx.alloc().buffer().writeBytes(content)
-                );
-                if (response.headers().contains(HttpHeaderNames.CONNECTION)) {
-                    // keep close/keep-alive
-                    fallbackResponse.headers().set(HttpHeaderNames.CONNECTION, response.headers().get(HttpHeaderNames.CONNECTION));
-                }
-                fallbackResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
-                fallbackResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
-                ReferenceCountUtil.release(response);
-                ctx.write(fallbackResponse, promise);
-            } else {
-                super.write(ctx, msg, promise);
-            }
 
-        } else {
-            super.write(ctx, msg, promise);
+        // Aggregated response (full http response from embedded channel when site.response is configured)
+        if (msg instanceof FullHttpResponse full) {
+            int status = full.status().code();
+            if (status == 503 || status == 500) {
+                FullHttpResponse fallback = buildFallback(ctx, full);
+                ReferenceCountUtil.release(full);
+                ctx.write(fallback, promise);
+                return;
+            }
+            // non-5xx aggregated response falls through and is forwarded unchanged
         }
+
+        // Streamed response (real backend when site.response is not configured)
+
+        Attribute<Boolean> suppressing = ctx.channel().attr(SUPPRESSING);
+
+        // Head of a streamed response: check for 5xx and replace if needed. The following body chunks will be dropped.
+        if (msg instanceof HttpResponse resp) {
+            int status = resp.status().code();
+            boolean replace = status == 503 || status == 500;
+            suppressing.set(replace);
+            if (replace) {
+                FullHttpResponse fallback = buildFallback(ctx, resp);
+                ReferenceCountUtil.release(msg);
+                ctx.write(fallback, promise);
+                return;
+            }
+            // non-5xx head falls through and is forwarded unchanged
+        }
+
+        // Origin body chunks of a streamed response we already replaced: drop them.
+        if (Boolean.TRUE.equals(suppressing.get()) && msg instanceof HttpContent chunk) {
+            chunk.release();
+            promise.setSuccess();
+            if (msg instanceof LastHttpContent) {
+                suppressing.set(Boolean.FALSE);
+            }
+            return;
+        }
+
+        super.write(ctx, msg, promise);
+    }
+
+    /**
+     * Builds a self-contained fallback response for a 500/503 {@code source} response. Copies the
+     * source's protocol version, status and {@code Connection} header (to preserve its keep-alive
+     * or close decision), then sets {@code Content-Type} and {@code Content-Length} for the chosen
+     * fallback body ({@link #unavailableContent} for 503, otherwise {@link #errorContent}). The
+     * {@code source} is only read here; releasing it is the caller's responsibility.
+     */
+    private FullHttpResponse buildFallback(ChannelHandlerContext ctx, HttpResponse source) {
+        byte[] content = (source.status().code() == 503) ? unavailableContent : errorContent;
+        FullHttpResponse fallback = new DefaultFullHttpResponse(
+                source.protocolVersion(),
+                source.status(),
+                ctx.alloc().buffer().writeBytes(content));
+        if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
+            fallback.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
+        }
+        fallback.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
+        fallback.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
+        return fallback;
     }
 
     /**

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -3,44 +3,25 @@ package org.sensepitch.edge;
 import static org.sensepitch.edge.FallbackConfig.DEFAULT_CONTENT_TYPE;
 
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.*;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * Replaces upstream 500/503 responses with an operator-configured fallback page (or text). Handles
  * both the aggregated {@link FullHttpResponse} (stub upstream) and the streamed form a real backend
  * produces ({@link HttpResponse} head + {@link HttpContent} chunks + {@link LastHttpContent}).
- *
  * @author Raid Thabet
  */
-@ChannelHandler.Sharable
 public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
-  private static final String CLASSPATH_PREFIX = "classpath:";
-
-  private static final String FILE_PREFIX = "file:";
-
   /**
-   * Per-connection flag: {@code TRUE} while the origin body chunks of a streamed 5xx response are
-   * being dropped after its head was replaced with the fallback. Stored on the channel (not as an
-   * instance field) so the handler can remain {@link ChannelHandler.Sharable @Sharable}.
+   * {@code true} while the origin body chunks of a streamed 5xx response are being dropped after
+   * its head was replaced with the fallback.
    */
-  private static final AttributeKey<Boolean> SUPPRESSING =
-      AttributeKey.valueOf(FallbackHandler.class, "suppressing");
+  private boolean suppressing;
 
   private final ResponseConfig unavailable; // fallbackConfig.unavailableResponse()
 
@@ -50,13 +31,15 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
   private final byte[] errorContent;
 
-  public FallbackHandler(FallbackConfig fallbackConfig) {
+  /**
+   * @param unavailableContent body of the 503 page fallback, {@code null} if it is a redirect
+   * @param errorContent body of the 500 page fallback, {@code null} if it is a redirect
+   */
+  FallbackHandler(FallbackConfig fallbackConfig, byte[] unavailableContent, byte[] errorContent) {
     this.unavailable = fallbackConfig.unavailableResponse();
     this.error = fallbackConfig.errorResponse();
-
-    // don't load a body for redirects at all
-    unavailableContent = unavailable.resolvedRedirect() != null ? null : pageBody(this.unavailable);
-    errorContent = error.resolvedRedirect() != null ? null : pageBody(this.error);
+    this.unavailableContent = unavailableContent;
+    this.errorContent = errorContent;
   }
 
   @Override
@@ -78,8 +61,6 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
     // Streamed response (real backend when site.response is not configured)
 
-    Attribute<Boolean> suppressing = ctx.channel().attr(SUPPRESSING);
-
     // Head of a streamed response: check for 5xx and replace if needed. The following body chunks
     // will be dropped.
     if (msg instanceof HttpResponse resp) {
@@ -87,7 +68,7 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
       boolean replace =
           status == 503
               || status == 500; // does this streamed response get swapped for the fallback?
-      suppressing.set(replace);
+      suppressing = replace;
       if (replace) {
         FullHttpResponse fallback = buildFallback(ctx, resp);
         ReferenceCountUtil.release(msg);
@@ -98,11 +79,11 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
     }
 
     // Origin body chunks of a streamed response we already replaced: drop them.
-    if (Boolean.TRUE.equals(suppressing.get()) && msg instanceof HttpContent chunk) {
+    if (suppressing && msg instanceof HttpContent chunk) {
       chunk.release();
       promise.setSuccess();
       if (msg instanceof LastHttpContent) {
-        suppressing.set(Boolean.FALSE);
+        suppressing = false;
       }
       return;
     }
@@ -150,67 +131,5 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
             cfg.contentType() != null ? cfg.contentType() : DEFAULT_CONTENT_TYPE);
     fallback.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
     return fallback;
-  }
-
-  /**
-   * Build the page body for a page (non-redirect) {@code cfg}: the resource named by {@link
-   * ResponseConfig#file()} (see {@link #openResource} for how the location is resolved), or else
-   * the inline {@link ResponseConfig#text()} as UTF-8. {@link ResponseConfig} already rejects
-   * setting both, and the constructor skips redirects, so this is reached only for page configs.
-   *
-   * @throws IllegalArgumentException if {@code cfg} has neither {@code file} nor {@code text} (an
-   *     empty page config)
-   */
-  private static byte[] pageBody(ResponseConfig cfg) {
-    if (cfg.file() != null) {
-      return readResource(cfg.file());
-    }
-    if (cfg.text() != null) {
-      return cfg.text().getBytes(StandardCharsets.UTF_8);
-    }
-    throw new IllegalArgumentException("page config has neither file nor text");
-  }
-
-  /**
-   * Read the resource fully; an unresolvable location is a configuration error that fails
-   * construction.
-   */
-  private static byte[] readResource(String file) {
-    try (InputStream in = openResource(file)) {
-      return in.readAllBytes();
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to read fallback page: " + file, e);
-    }
-  }
-
-  /**
-   * Open the resource named by {@code location}. An explicit {@code classpath:} or {@code file:}
-   * scheme picks exactly that source; a bare (schemeless) location is tried on the filesystem first
-   * and then on the classpath.
-   */
-  private static InputStream openResource(String location) throws IOException {
-    if (location.startsWith(CLASSPATH_PREFIX)) {
-      return openClasspath(location.substring(CLASSPATH_PREFIX.length()));
-    }
-    if (location.startsWith(FILE_PREFIX)) {
-      return new FileInputStream(location.substring(FILE_PREFIX.length()));
-    }
-    // No scheme: try the filesystem first, then the classpath.
-    Path filePath = Path.of(location);
-    if (Files.isReadable(filePath)) {
-      return Files.newInputStream(filePath);
-    }
-    return openClasspath(location);
-  }
-
-  private static InputStream openClasspath(String path) throws IOException {
-    if (path.startsWith("/")) {
-      path = path.substring(1);
-    }
-    InputStream in = FallbackHandler.class.getClassLoader().getResourceAsStream(path);
-    if (in == null) {
-      throw new FileNotFoundException("Classpath resource not found: " + path);
-    }
-    return in;
   }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -13,6 +13,7 @@ import io.netty.util.ReferenceCountUtil;
  * Replaces upstream 500/503 responses with an operator-configured fallback page (or text). Handles
  * both the aggregated {@link FullHttpResponse} (stub upstream) and the streamed form a real backend
  * produces ({@link HttpResponse} head + {@link HttpContent} chunks + {@link LastHttpContent}).
+ *
  * @author Raid Thabet
  */
 public class FallbackHandler extends ChannelOutboundHandlerAdapter {
@@ -48,88 +49,130 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
     // Aggregated response (full http response from embedded channel when site.response is
     // configured)
-    if (msg instanceof FullHttpResponse full) {
-      int status = full.status().code();
-      if (status == 503 || status == 500) {
-        FullHttpResponse fallback = buildFallback(ctx, full);
-        ReferenceCountUtil.release(full);
-        ctx.write(fallback, promise);
-        return;
-      }
-      // non-5xx aggregated response falls through and is forwarded unchanged
+    if (msg instanceof FullHttpResponse aggregated) {
+      handleAggregatedResponse(ctx, aggregated, promise);
+      return;
     }
 
     // Streamed response (real backend when site.response is not configured)
-
-    // Head of a streamed response: check for 5xx and replace if needed. The following body chunks
-    // will be dropped.
-    if (msg instanceof HttpResponse resp) {
-      int status = resp.status().code();
-      boolean replace =
-          status == 503
-              || status == 500; // does this streamed response get swapped for the fallback?
-      suppressing = replace;
-      if (replace) {
-        FullHttpResponse fallback = buildFallback(ctx, resp);
-        ReferenceCountUtil.release(msg);
-        ctx.write(fallback, promise);
-        return;
-      }
-      // non-5xx head falls through and is forwarded unchanged
+    if (msg instanceof HttpResponse head) {
+      handleStreamedHead(ctx, head, promise);
+      return;
     }
-
-    // Origin body chunks of a streamed response we already replaced: drop them.
-    if (suppressing && msg instanceof HttpContent chunk) {
-      chunk.release();
-      promise.setSuccess();
-      if (msg instanceof LastHttpContent) {
-        suppressing = false;
-      }
+    if (msg instanceof HttpContent chunk) {
+      handleStreamedContent(ctx, chunk, promise);
       return;
     }
 
     super.write(ctx, msg, promise);
   }
 
+  private void handleAggregatedResponse(
+      ChannelHandlerContext ctx, FullHttpResponse aggregated, ChannelPromise promise)
+      throws Exception {
+    if (!isFallbackStatus(aggregated.status().code())) {
+      suppressing = false;
+      super.write(ctx, aggregated, promise);
+      return;
+    }
+    writeFallback(ctx, aggregated, promise);
+  }
+
+  private void handleStreamedHead(
+      ChannelHandlerContext ctx, HttpResponse head, ChannelPromise promise) throws Exception {
+    suppressing = isFallbackStatus(head.status().code());
+    if (!suppressing) {
+      super.write(ctx, head, promise);
+      return;
+    }
+    writeFallback(ctx, head, promise);
+  }
+
+  private void handleStreamedContent(
+      ChannelHandlerContext ctx, HttpContent chunk, ChannelPromise promise) throws Exception {
+    if (!suppressing) {
+      super.write(ctx, chunk, promise);
+      return;
+    }
+    chunk.release();
+    promise.setSuccess();
+    if (chunk instanceof LastHttpContent) {
+      suppressing = false;
+    }
+  }
+
+  private void writeFallback(
+      ChannelHandlerContext ctx, HttpResponse source, ChannelPromise promise) {
+    FullHttpResponse fallback = buildFallback(ctx, source);
+    ReferenceCountUtil.release(source);
+    ctx.write(fallback, promise);
+  }
+
   private FullHttpResponse buildFallback(ChannelHandlerContext ctx, HttpResponse source) {
-    boolean isDown = source.status().code() == 503;
-    ResponseConfig cfg = isDown ? unavailable : error;
+    boolean serviceUnavailable =
+        source.status().code() == HttpResponseStatus.SERVICE_UNAVAILABLE.code();
+    ResponseConfig cfg = serviceUnavailable ? unavailable : error;
     Fallback.Redirect redirect = Fallback.resolvedRedirect(cfg.location(), cfg.status());
 
-    // Redirect fallback
     if (redirect != null) {
-      int code = redirect.status();
-      FullHttpResponse redirectResponse =
-          new DefaultFullHttpResponse(
-              source.protocolVersion(), HttpResponseStatus.valueOf(code), Unpooled.EMPTY_BUFFER);
-      if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
-        redirectResponse
-            .headers()
-            .set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
-      }
-      redirectResponse.headers().set(HttpHeaderNames.LOCATION, redirect.location());
-      redirectResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
-      return redirectResponse;
+      return buildRedirectFallback(source, redirect);
     }
+    byte[] content = serviceUnavailable ? unavailableContent : errorContent;
+    return buildPageFallback(ctx, source, cfg, content);
+  }
 
-    // Page fallback
-    byte[] content = isDown ? unavailableContent : errorContent;
+  private FullHttpResponse buildRedirectFallback(HttpResponse source, Fallback.Redirect redirect) {
+    FullHttpResponse redirectResponse =
+        new DefaultFullHttpResponse(
+            source.protocolVersion(),
+            HttpResponseStatus.valueOf(redirect.status()),
+            Unpooled.EMPTY_BUFFER);
+    if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
+      copyConnectionHeaderIfPresent(source, redirectResponse);
+    }
+    setLocationAndLengthHeaders(redirectResponse, redirect.location());
+    return redirectResponse;
+  }
+
+  private FullHttpResponse buildPageFallback(
+      ChannelHandlerContext ctx, HttpResponse source, ResponseConfig cfg, byte[] content) {
     HttpResponseStatus status =
         cfg.status() != 0 ? HttpResponseStatus.valueOf(cfg.status()) : source.status();
     FullHttpResponse fallback =
         new DefaultFullHttpResponse(
             source.protocolVersion(), status, ctx.alloc().buffer().writeBytes(content));
     if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
-      fallback
+      copyConnectionHeaderIfPresent(source, fallback);
+    }
+    setContentTypeAndLengthHeaders(fallback, cfg, content);
+    return fallback;
+  }
+
+  private boolean isFallbackStatus(int status) {
+    return status == HttpResponseStatus.SERVICE_UNAVAILABLE.code()
+        || status == HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+  }
+
+  private void copyConnectionHeaderIfPresent(HttpResponse source, FullHttpResponse response) {
+    if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
+      response
           .headers()
           .set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
     }
+  }
+
+  private void setContentTypeAndLengthHeaders(
+      FullHttpResponse fallback, ResponseConfig cfg, byte[] content) {
     fallback
         .headers()
         .set(
             HttpHeaderNames.CONTENT_TYPE,
             cfg.contentType() != null ? cfg.contentType() : DEFAULT_CONTENT_TYPE);
     fallback.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
-    return fallback;
+  }
+
+  private void setLocationAndLengthHeaders(FullHttpResponse response, String location) {
+    response.headers().set(HttpHeaderNames.LOCATION, location);
+    response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
   }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -94,7 +94,7 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
   private FullHttpResponse buildFallback(ChannelHandlerContext ctx, HttpResponse source) {
     boolean isDown = source.status().code() == 503;
     ResponseConfig cfg = isDown ? unavailable : error;
-    ResponseConfig.Redirect redirect = cfg.resolvedRedirect();
+    Fallback.Redirect redirect = Fallback.resolvedRedirect(cfg.location(), cfg.status());
 
     // Redirect fallback
     if (redirect != null) {

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -1,5 +1,7 @@
 package org.sensepitch.edge;
 
+import static org.sensepitch.edge.FallbackConfig.DEFAULT_CONTENT_TYPE;
+
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -9,14 +11,11 @@ import io.netty.handler.codec.http.*;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.sensepitch.edge.FallbackConfig.DEFAULT_CONTENT_TYPE;
 
 /**
  * Replaces upstream 500/503 responses with an operator-configured fallback page (or text). Handles
@@ -28,151 +27,157 @@ import static org.sensepitch.edge.FallbackConfig.DEFAULT_CONTENT_TYPE;
 @ChannelHandler.Sharable
 public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
-    static ProxyLogger LOG = ProxyLogger.get(FallbackHandler.class);
+  static ProxyLogger LOG = ProxyLogger.get(FallbackHandler.class);
 
-    /**
-     * Per-connection flag: {@code TRUE} while the origin body chunks of a streamed 5xx response are
-     * being dropped after its head was replaced with the fallback. Stored on the channel (not as an
-     * instance field) so the handler can remain {@link ChannelHandler.Sharable @Sharable}.
-     */
-    private static final AttributeKey<Boolean> SUPPRESSING =
-            AttributeKey.valueOf(FallbackHandler.class, "suppressing");
+  /**
+   * Per-connection flag: {@code TRUE} while the origin body chunks of a streamed 5xx response are
+   * being dropped after its head was replaced with the fallback. Stored on the channel (not as an
+   * instance field) so the handler can remain {@link ChannelHandler.Sharable @Sharable}.
+   */
+  private static final AttributeKey<Boolean> SUPPRESSING =
+      AttributeKey.valueOf(FallbackHandler.class, "suppressing");
 
-    private final ResponseConfig unavailable;   // fallbackConfig.unavailableResponse()
+  private final ResponseConfig unavailable; // fallbackConfig.unavailableResponse()
 
-    private final ResponseConfig error;
+  private final ResponseConfig error;
 
-    private final byte[] unavailableContent;
+  private final byte[] unavailableContent;
 
-    private final byte[] errorContent;
+  private final byte[] errorContent;
 
-    public FallbackHandler(FallbackConfig fallbackConfig) {
-        this.unavailable = fallbackConfig.unavailableResponse();
-        this.error = fallbackConfig.errorResponse();
+  public FallbackHandler(FallbackConfig fallbackConfig) {
+    this.unavailable = fallbackConfig.unavailableResponse();
+    this.error = fallbackConfig.errorResponse();
 
-        unavailableContent = loadOrDefault(
-                this.unavailable.file(),
-                this.unavailable.text()
-        );
-        errorContent = loadOrDefault(
-                this.error.file(),
-                this.error.text()
-        );
+    unavailableContent = loadOrDefault(this.unavailable.file(), this.unavailable.text());
+    errorContent = loadOrDefault(this.error.file(), this.error.text());
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+      throws Exception {
+
+    // Aggregated response (full http response from embedded channel when site.response is
+    // configured)
+    if (msg instanceof FullHttpResponse full) {
+      int status = full.status().code();
+      if (status == 503 || status == 500) {
+        FullHttpResponse fallback = buildFallback(ctx, full);
+        ReferenceCountUtil.release(full);
+        ctx.write(fallback, promise);
+        return;
+      }
+      // non-5xx aggregated response falls through and is forwarded unchanged
     }
 
-    @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    // Streamed response (real backend when site.response is not configured)
 
-        // Aggregated response (full http response from embedded channel when site.response is configured)
-        if (msg instanceof FullHttpResponse full) {
-            int status = full.status().code();
-            if (status == 503 || status == 500) {
-                FullHttpResponse fallback = buildFallback(ctx, full);
-                ReferenceCountUtil.release(full);
-                ctx.write(fallback, promise);
-                return;
-            }
-            // non-5xx aggregated response falls through and is forwarded unchanged
-        }
+    Attribute<Boolean> suppressing = ctx.channel().attr(SUPPRESSING);
 
-        // Streamed response (real backend when site.response is not configured)
-
-        Attribute<Boolean> suppressing = ctx.channel().attr(SUPPRESSING);
-
-        // Head of a streamed response: check for 5xx and replace if needed. The following body chunks will be dropped.
-        if (msg instanceof HttpResponse resp) {
-            int status = resp.status().code();
-            boolean replace = status == 503 || status == 500; // does this streamed response get swapped for the fallback?
-            suppressing.set(replace);
-            if (replace) {
-                FullHttpResponse fallback = buildFallback(ctx, resp);
-                ReferenceCountUtil.release(msg);
-                ctx.write(fallback, promise);
-                return;
-            }
-            // non-5xx head falls through and is forwarded unchanged
-        }
-
-        // Origin body chunks of a streamed response we already replaced: drop them.
-        if (Boolean.TRUE.equals(suppressing.get()) && msg instanceof HttpContent chunk) {
-            chunk.release();
-            promise.setSuccess();
-            if (msg instanceof LastHttpContent) {
-                suppressing.set(Boolean.FALSE);
-            }
-            return;
-        }
-
-        super.write(ctx, msg, promise);
+    // Head of a streamed response: check for 5xx and replace if needed. The following body chunks
+    // will be dropped.
+    if (msg instanceof HttpResponse resp) {
+      int status = resp.status().code();
+      boolean replace =
+          status == 503
+              || status == 500; // does this streamed response get swapped for the fallback?
+      suppressing.set(replace);
+      if (replace) {
+        FullHttpResponse fallback = buildFallback(ctx, resp);
+        ReferenceCountUtil.release(msg);
+        ctx.write(fallback, promise);
+        return;
+      }
+      // non-5xx head falls through and is forwarded unchanged
     }
 
-    private FullHttpResponse buildFallback(ChannelHandlerContext ctx, HttpResponse source) {
-        boolean isDown = source.status().code() == 503;
-        ResponseConfig cfg = isDown ? unavailable : error;
-        ResponseConfig.Redirect redirect = cfg.resolvedRedirect();
-
-        // Redirect fallback
-        if (redirect != null) {
-            int code = redirect.status();
-            FullHttpResponse redirectResponse = new DefaultFullHttpResponse(
-                    source.protocolVersion(), HttpResponseStatus.valueOf(code), Unpooled.EMPTY_BUFFER);
-            if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
-                redirectResponse.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
-            }
-            redirectResponse.headers().set(HttpHeaderNames.LOCATION, redirect.location());
-            redirectResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
-            return redirectResponse;
-        }
-
-        // Page fallback
-        byte[] content = isDown ? unavailableContent : errorContent;
-        HttpResponseStatus status = cfg.status() != 0
-                ? HttpResponseStatus.valueOf(cfg.status())
-                : source.status();
-        FullHttpResponse fallback = new DefaultFullHttpResponse(
-                source.protocolVersion(),
-                status,
-                ctx.alloc().buffer().writeBytes(content));
-        if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
-            fallback.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
-        }
-        fallback.headers().set(HttpHeaderNames.CONTENT_TYPE, cfg.contentType() != null ? cfg.contentType() : DEFAULT_CONTENT_TYPE);
-        fallback.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
-        return fallback;
+    // Origin body chunks of a streamed response we already replaced: drop them.
+    if (Boolean.TRUE.equals(suppressing.get()) && msg instanceof HttpContent chunk) {
+      chunk.release();
+      promise.setSuccess();
+      if (msg instanceof LastHttpContent) {
+        suppressing.set(Boolean.FALSE);
+      }
+      return;
     }
 
-    /**
-     * Load an HTML page for the fallback response. Tries, in order:
-     * <ol>
-     *     <li> a file on disk at {@code path} (operator-provided override)</li>
-     *     <li> a classpath resource at {@code path} (bundled default page)</li>
-     *     <li> {@code defaultText} as plain UTF-8 (last-resort)</li>
-     * </ol>
-     */
-    private static byte[] loadOrDefault(String path, String defaultText) {
-        // in case a file is provided
-        if (path != null) {
-            try {
-                Path filePath = Path.of(path);
-                if (Files.isReadable(filePath)) {
-                    return Files.readAllBytes(filePath);
-                }
-            } catch (IOException e) {
-                LOG.error("Failed to read fallback page from file: " + path, e);
-            }
+    super.write(ctx, msg, promise);
+  }
 
-            try (InputStream in = FallbackHandler.class.getClassLoader().getResourceAsStream(path)) {
-                if (in != null) {
-                    return in.readAllBytes();
-                }
-            } catch (IOException e) {
-                LOG.error("Failed to read fallback page from classpath: " + path, e);
-            }
-        }
+  private FullHttpResponse buildFallback(ChannelHandlerContext ctx, HttpResponse source) {
+    boolean isDown = source.status().code() == 503;
+    ResponseConfig cfg = isDown ? unavailable : error;
+    ResponseConfig.Redirect redirect = cfg.resolvedRedirect();
 
-        // in case a file is not provided or not found
-        String text = defaultText != null ? defaultText : "Unknown problem occurred";
-        return text.getBytes(StandardCharsets.UTF_8);
+    // Redirect fallback
+    if (redirect != null) {
+      int code = redirect.status();
+      FullHttpResponse redirectResponse =
+          new DefaultFullHttpResponse(
+              source.protocolVersion(), HttpResponseStatus.valueOf(code), Unpooled.EMPTY_BUFFER);
+      if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
+        redirectResponse
+            .headers()
+            .set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
+      }
+      redirectResponse.headers().set(HttpHeaderNames.LOCATION, redirect.location());
+      redirectResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+      return redirectResponse;
     }
 
+    // Page fallback
+    byte[] content = isDown ? unavailableContent : errorContent;
+    HttpResponseStatus status =
+        cfg.status() != 0 ? HttpResponseStatus.valueOf(cfg.status()) : source.status();
+    FullHttpResponse fallback =
+        new DefaultFullHttpResponse(
+            source.protocolVersion(), status, ctx.alloc().buffer().writeBytes(content));
+    if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
+      fallback
+          .headers()
+          .set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
+    }
+    fallback
+        .headers()
+        .set(
+            HttpHeaderNames.CONTENT_TYPE,
+            cfg.contentType() != null ? cfg.contentType() : DEFAULT_CONTENT_TYPE);
+    fallback.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
+    return fallback;
+  }
+
+  /**
+   * Load an HTML page for the fallback response. Tries, in order:
+   *
+   * <ol>
+   *   <li>a file on disk at {@code path} (operator-provided override)
+   *   <li>a classpath resource at {@code path} (bundled default page)
+   *   <li>{@code defaultText} as plain UTF-8 (last-resort)
+   * </ol>
+   */
+  private static byte[] loadOrDefault(String path, String defaultText) {
+    // in case a file is provided
+    if (path != null) {
+      try {
+        Path filePath = Path.of(path);
+        if (Files.isReadable(filePath)) {
+          return Files.readAllBytes(filePath);
+        }
+      } catch (IOException e) {
+        LOG.error("Failed to read fallback page from file: " + path, e);
+      }
+
+      try (InputStream in = FallbackHandler.class.getClassLoader().getResourceAsStream(path)) {
+        if (in != null) {
+          return in.readAllBytes();
+        }
+      } catch (IOException e) {
+        LOG.error("Failed to read fallback page from classpath: " + path, e);
+      }
+    }
+
+    // in case a file is not provided or not found
+    String text = defaultText != null ? defaultText : "Unknown problem occurred";
+    return text.getBytes(StandardCharsets.UTF_8);
+  }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -1,0 +1,94 @@
+package org.sensepitch.edge;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.ReferenceCountUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@ChannelHandler.Sharable
+public class FallbackHandler extends ChannelOutboundHandlerAdapter {
+
+    static ProxyLogger LOG = ProxyLogger.get(FallbackHandler.class);
+
+    private final byte[] unavailableContent;
+
+    private final byte[] errorContent;
+
+    public FallbackHandler(FallbackConfig fallbackConfig) {
+        unavailableContent = loadOrDefault(fallbackConfig.unavailablePage(), fallbackConfig.unavailableText());
+        errorContent = loadOrDefault(fallbackConfig.errorPage(), fallbackConfig.errorText());
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof FullHttpResponse response) {
+            int status = response.status().code();
+            if (status == 503 || status == 500) {
+                byte[] content = (status == 503) ? unavailableContent : errorContent;
+                FullHttpResponse fallbackResponse = new DefaultFullHttpResponse(
+                        response.protocolVersion(),
+                        response.status(),
+                        ctx.alloc().buffer().writeBytes(content)
+                );
+                if (response.headers().contains(HttpHeaderNames.CONNECTION)) {
+                    // keep close/keep-alive
+                    fallbackResponse.headers().set(HttpHeaderNames.CONNECTION, response.headers().get(HttpHeaderNames.CONNECTION));
+                }
+                fallbackResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
+                fallbackResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
+                ReferenceCountUtil.release(response);
+                ctx.write(fallbackResponse, promise);
+            } else {
+                super.write(ctx, msg, promise);
+            }
+
+        } else {
+            super.write(ctx, msg, promise);
+        }
+    }
+
+    /**
+     * Load an HTML page for the fallback response. Tries, in order:
+     * <ol>
+     *     <li> a file on disk at {@code path} (operator-provided override)</li>
+     *     <li> a classpath resource at {@code path} (bundled default page)</li>
+     *     <li> {@code defaultText} as plain UTF-8 (last-resort)</li>
+     * </ol>
+     */
+    private static byte[] loadOrDefault(String path, String defaultText) {
+        // in case a file is provided
+        if (path != null) {
+            try {
+                Path filePath = Path.of(path);
+                if (Files.isReadable(filePath)) {
+                    return Files.readAllBytes(filePath);
+                }
+            } catch (IOException e) {
+                LOG.error("Failed to read fallback page from file: " + path, e);
+            }
+
+            try (InputStream in = FallbackHandler.class.getClassLoader().getResourceAsStream(path)) {
+                if (in != null) {
+                    return in.readAllBytes();
+                }
+            } catch (IOException e) {
+                LOG.error("Failed to read fallback page from classpath: " + path, e);
+            }
+        }
+
+        // in case a file is not provided or not found
+        String text = defaultText != null ? defaultText : "Unknown problem occurred";
+        return text.getBytes(StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -54,8 +54,9 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
     this.unavailable = fallbackConfig.unavailableResponse();
     this.error = fallbackConfig.errorResponse();
 
-    unavailableContent = loadOrDefault(this.unavailable.file(), this.unavailable.text());
-    errorContent = loadOrDefault(this.error.file(), this.error.text());
+    // don't load a body for redirects at all
+    unavailableContent = unavailable.resolvedRedirect() != null ? null : pageBody(this.unavailable);
+    errorContent = error.resolvedRedirect() != null ? null : pageBody(this.error);
   }
 
   @Override
@@ -152,28 +153,34 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
   }
 
   /**
-   * Load the fallback page body. When {@code location} is set, its scheme selects the source:
+   * Build the page body for a page (non-redirect) {@code cfg}: the resource named by {@link
+   * ResponseConfig#file()} (see {@link #openResource} for how the location is resolved), or else
+   * the inline {@link ResponseConfig#text()} as UTF-8. {@link ResponseConfig} already rejects
+   * setting both, and the constructor skips redirects, so this is reached only for page configs.
    *
-   * <ul>
-   *   <li>{@code classpath:<path>} - a bundled resource on the classpath, only
-   *   <li>{@code file:<path>} - a file on disk, only
-   *   <li>no scheme - try the filesystem first, then fall back to the classpath
-   * </ul>
-   *
-   * A resource that resolves to nothing is a hard configuration error that fails construction. When
-   * {@code location} is {@code null} the {@code text} (or a last-resort string) is used as a plain
-   * UTF-8 body.
+   * @throws IllegalArgumentException if {@code cfg} has neither {@code file} nor {@code text} (an
+   *     empty page config)
    */
-  private static byte[] loadOrDefault(String location, String text) {
-    if (location != null) {
-      try (InputStream in = openResource(location)) {
-        return in.readAllBytes();
-      } catch (IOException e) {
-        throw new UncheckedIOException("Failed to read fallback page: " + location, e);
-      }
+  private static byte[] pageBody(ResponseConfig cfg) {
+    if (cfg.file() != null) {
+      return readResource(cfg.file());
     }
-    text = text != null ? text : "Unknown problem occurred";
-    return text.getBytes(StandardCharsets.UTF_8);
+    if (cfg.text() != null) {
+      return cfg.text().getBytes(StandardCharsets.UTF_8);
+    }
+    throw new IllegalArgumentException("page config has neither file nor text");
+  }
+
+  /**
+   * Read the resource fully; an unresolvable location is a configuration error that fails
+   * construction.
+   */
+  private static byte[] readResource(String file) {
+    try (InputStream in = openResource(file)) {
+      return in.readAllBytes();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read fallback page: " + file, e);
+    }
   }
 
   /**

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -11,8 +11,11 @@ import io.netty.handler.codec.http.*;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,7 +30,9 @@ import java.nio.file.Path;
 @ChannelHandler.Sharable
 public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
-  static ProxyLogger LOG = ProxyLogger.get(FallbackHandler.class);
+  private static final String CLASSPATH_PREFIX = "classpath:";
+
+  private static final String FILE_PREFIX = "file:";
 
   /**
    * Per-connection flag: {@code TRUE} while the origin body chunks of a streamed 5xx response are
@@ -147,37 +152,58 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
   }
 
   /**
-   * Load an HTML page for the fallback response. Tries, in order:
+   * Load the fallback page body. When {@code location} is set, its scheme selects the source:
    *
-   * <ol>
-   *   <li>a file on disk at {@code path} (operator-provided override)
-   *   <li>a classpath resource at {@code path} (bundled default page)
-   *   <li>{@code defaultText} as plain UTF-8 (last-resort)
-   * </ol>
+   * <ul>
+   *   <li>{@code classpath:<path>} - a bundled resource on the classpath, only
+   *   <li>{@code file:<path>} - a file on disk, only
+   *   <li>no scheme - try the filesystem first, then fall back to the classpath
+   * </ul>
+   *
+   * A resource that resolves to nothing is a hard configuration error that fails construction. When
+   * {@code location} is {@code null} the {@code text} (or a last-resort string) is used as a plain
+   * UTF-8 body.
    */
-  private static byte[] loadOrDefault(String path, String defaultText) {
-    // in case a file is provided
-    if (path != null) {
-      try {
-        Path filePath = Path.of(path);
-        if (Files.isReadable(filePath)) {
-          return Files.readAllBytes(filePath);
-        }
+  private static byte[] loadOrDefault(String location, String text) {
+    if (location != null) {
+      try (InputStream in = openResource(location)) {
+        return in.readAllBytes();
       } catch (IOException e) {
-        LOG.error("Failed to read fallback page from file: " + path, e);
-      }
-
-      try (InputStream in = FallbackHandler.class.getClassLoader().getResourceAsStream(path)) {
-        if (in != null) {
-          return in.readAllBytes();
-        }
-      } catch (IOException e) {
-        LOG.error("Failed to read fallback page from classpath: " + path, e);
+        throw new UncheckedIOException("Failed to read fallback page: " + location, e);
       }
     }
-
-    // in case a file is not provided or not found
-    String text = defaultText != null ? defaultText : "Unknown problem occurred";
+    text = text != null ? text : "Unknown problem occurred";
     return text.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Open the resource named by {@code location}. An explicit {@code classpath:} or {@code file:}
+   * scheme picks exactly that source; a bare (schemeless) location is tried on the filesystem first
+   * and then on the classpath.
+   */
+  private static InputStream openResource(String location) throws IOException {
+    if (location.startsWith(CLASSPATH_PREFIX)) {
+      return openClasspath(location.substring(CLASSPATH_PREFIX.length()));
+    }
+    if (location.startsWith(FILE_PREFIX)) {
+      return new FileInputStream(location.substring(FILE_PREFIX.length()));
+    }
+    // No scheme: try the filesystem first, then the classpath.
+    Path filePath = Path.of(location);
+    if (Files.isReadable(filePath)) {
+      return Files.newInputStream(filePath);
+    }
+    return openClasspath(location);
+  }
+
+  private static InputStream openClasspath(String path) throws IOException {
+    if (path.startsWith("/")) {
+      path = path.substring(1);
+    }
+    InputStream in = FallbackHandler.class.getClassLoader().getResourceAsStream(path);
+    if (in == null) {
+      throw new FileNotFoundException("Classpath resource not found: " + path);
+    }
+    return in;
   }
 }

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -15,6 +15,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.sensepitch.edge.FallbackConfig.DEFAULT_CONTENT_TYPE;
+
 /**
  * Replaces upstream 500/503 responses with an operator-configured fallback page (or text). Handles
  * both the aggregated {@link FullHttpResponse} (stub upstream) and the streamed form a real backend
@@ -130,7 +132,7 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
         if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
             fallback.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
         }
-        fallback.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
+        fallback.headers().set(HttpHeaderNames.CONTENT_TYPE, cfg.contentType() != null ? cfg.contentType() : DEFAULT_CONTENT_TYPE);
         fallback.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.length);
         return fallback;
     }

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -1,5 +1,6 @@
 package org.sensepitch.edge;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -114,7 +115,7 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
         if (redirect != null) {
             int code = redirect.status();
             FullHttpResponse redirectResponse = new DefaultFullHttpResponse(
-                    source.protocolVersion(), HttpResponseStatus.valueOf(code), ctx.alloc().buffer(0));
+                    source.protocolVersion(), HttpResponseStatus.valueOf(code), Unpooled.EMPTY_BUFFER);
             if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
                 redirectResponse.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
             }
@@ -125,9 +126,12 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
 
         // Page fallback
         byte[] content = isDown ? unavailableContent : errorContent;
+        HttpResponseStatus status = cfg.status() != 0
+                ? HttpResponseStatus.valueOf(cfg.status())
+                : source.status();
         FullHttpResponse fallback = new DefaultFullHttpResponse(
                 source.protocolVersion(),
-                source.status(),
+                status,
                 ctx.alloc().buffer().writeBytes(content));
         if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
             fallback.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));

--- a/src/main/java/org/sensepitch/edge/FallbackHandler.java
+++ b/src/main/java/org/sensepitch/edge/FallbackHandler.java
@@ -35,13 +35,26 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
     private static final AttributeKey<Boolean> SUPPRESSING =
             AttributeKey.valueOf(FallbackHandler.class, "suppressing");
 
+    private final ResponseConfig unavailable;   // fallbackConfig.unavailableResponse()
+
+    private final ResponseConfig error;
+
     private final byte[] unavailableContent;
 
     private final byte[] errorContent;
 
     public FallbackHandler(FallbackConfig fallbackConfig) {
-        unavailableContent = loadOrDefault(fallbackConfig.unavailablePage(), fallbackConfig.unavailableText());
-        errorContent = loadOrDefault(fallbackConfig.errorPage(), fallbackConfig.errorText());
+        this.unavailable = fallbackConfig.unavailableResponse();
+        this.error = fallbackConfig.errorResponse();
+
+        unavailableContent = loadOrDefault(
+                this.unavailable.file(),
+                this.unavailable.text()
+        );
+        errorContent = loadOrDefault(
+                this.error.file(),
+                this.error.text()
+        );
     }
 
     @Override
@@ -66,7 +79,7 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
         // Head of a streamed response: check for 5xx and replace if needed. The following body chunks will be dropped.
         if (msg instanceof HttpResponse resp) {
             int status = resp.status().code();
-            boolean replace = status == 503 || status == 500;
+            boolean replace = status == 503 || status == 500; // does this streamed response get swapped for the fallback?
             suppressing.set(replace);
             if (replace) {
                 FullHttpResponse fallback = buildFallback(ctx, resp);
@@ -90,15 +103,26 @@ public class FallbackHandler extends ChannelOutboundHandlerAdapter {
         super.write(ctx, msg, promise);
     }
 
-    /**
-     * Builds a self-contained fallback response for a 500/503 {@code source} response. Copies the
-     * source's protocol version, status and {@code Connection} header (to preserve its keep-alive
-     * or close decision), then sets {@code Content-Type} and {@code Content-Length} for the chosen
-     * fallback body ({@link #unavailableContent} for 503, otherwise {@link #errorContent}). The
-     * {@code source} is only read here; releasing it is the caller's responsibility.
-     */
     private FullHttpResponse buildFallback(ChannelHandlerContext ctx, HttpResponse source) {
-        byte[] content = (source.status().code() == 503) ? unavailableContent : errorContent;
+        boolean isDown = source.status().code() == 503;
+        ResponseConfig cfg = isDown ? unavailable : error;
+        ResponseConfig.Redirect redirect = cfg.resolvedRedirect();
+
+        // Redirect fallback
+        if (redirect != null) {
+            int code = redirect.status();
+            FullHttpResponse redirectResponse = new DefaultFullHttpResponse(
+                    source.protocolVersion(), HttpResponseStatus.valueOf(code), ctx.alloc().buffer(0));
+            if (source.headers().contains(HttpHeaderNames.CONNECTION)) {
+                redirectResponse.headers().set(HttpHeaderNames.CONNECTION, source.headers().get(HttpHeaderNames.CONNECTION));
+            }
+            redirectResponse.headers().set(HttpHeaderNames.LOCATION, redirect.location());
+            redirectResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+            return redirectResponse;
+        }
+
+        // Page fallback
+        byte[] content = isDown ? unavailableContent : errorContent;
         FullHttpResponse fallback = new DefaultFullHttpResponse(
                 source.protocolVersion(),
                 source.status(),

--- a/src/main/java/org/sensepitch/edge/Protection.java
+++ b/src/main/java/org/sensepitch/edge/Protection.java
@@ -34,8 +34,7 @@ public class Protection {
       plugins.add(new DeflectorHandler(deflector));
     }
     if (!plugins.isEmpty()) {
-      ProtectionPlugin plugin =
-          plugins.size() == 1 ? plugins.get(0) : new ProtectionChain(plugins);
+      ProtectionPlugin plugin = plugins.size() == 1 ? plugins.get(0) : new ProtectionChain(plugins);
       if (bypass != null) {
         plugin = new BypassProtectionPlugin(bypass, plugin);
       }

--- a/src/main/java/org/sensepitch/edge/ProtectionBypassConfig.java
+++ b/src/main/java/org/sensepitch/edge/ProtectionBypassConfig.java
@@ -1,14 +1,10 @@
 package org.sensepitch.edge;
 
-import lombok.Builder;
-
 import java.util.List;
+import lombok.Builder;
 
 /**
  * @author Jens Wilke
  */
 @Builder(toBuilder = true)
-public record ProtectionBypassConfig(
-  List<String> uris, List<String> remotes
-) {
-}
+public record ProtectionBypassConfig(List<String> uris, List<String> remotes) {}

--- a/src/main/java/org/sensepitch/edge/ProtectionConfig.java
+++ b/src/main/java/org/sensepitch/edge/ProtectionConfig.java
@@ -9,5 +9,6 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record ProtectionConfig(
     boolean disable,
-    ProtectionBypassConfig bypass, DeflectorConfig deflector,
+    ProtectionBypassConfig bypass,
+    DeflectorConfig deflector,
     List<CookieGateConfig> cookieGates) {}

--- a/src/main/java/org/sensepitch/edge/Proxy.java
+++ b/src/main/java/org/sensepitch/edge/Proxy.java
@@ -245,7 +245,8 @@ public class Proxy implements ProxyContext {
     if (unservicedHost != null) {
       pipeline.addLast(unservicedHost.newHandler());
     }
-    ChannelHandler initialFallbackHandler = new FallbackHandler(FallbackConfig.DEFAULTS.merge(config.fallback()));
+    ChannelHandler initialFallbackHandler =
+        new FallbackHandler(FallbackConfig.DEFAULTS.merge(config.fallback()));
     pipeline.addLast("siteSelector", new SiteSelectorHandler(siteSelector));
     pipeline.addLast("fallback", initialFallbackHandler);
     pipeline.addLast("protection", dummy404Handler);

--- a/src/main/java/org/sensepitch/edge/Proxy.java
+++ b/src/main/java/org/sensepitch/edge/Proxy.java
@@ -245,7 +245,7 @@ public class Proxy implements ProxyContext {
     if (unservicedHost != null) {
       pipeline.addLast(unservicedHost.newHandler());
     }
-    ChannelHandler initialFallbackHandler = new FallbackHandler(FallbackConfig.DEFAULT.merge(config.fallback()));
+    ChannelHandler initialFallbackHandler = new FallbackHandler(FallbackConfig.DEFAULTS.merge(config.fallback()));
     pipeline.addLast("siteSelector", new SiteSelectorHandler(siteSelector));
     pipeline.addLast("fallback", initialFallbackHandler);
     pipeline.addLast("protection", dummy404Handler);

--- a/src/main/java/org/sensepitch/edge/Proxy.java
+++ b/src/main/java/org/sensepitch/edge/Proxy.java
@@ -245,10 +245,8 @@ public class Proxy implements ProxyContext {
     if (unservicedHost != null) {
       pipeline.addLast(unservicedHost.newHandler());
     }
-    ChannelHandler initialFallbackHandler =
-        new FallbackHandler(FallbackConfig.DEFAULTS.merge(config.fallback()));
     pipeline.addLast("siteSelector", new SiteSelectorHandler(siteSelector));
-    pipeline.addLast("fallback", initialFallbackHandler);
+    pipeline.addLast("fallback", dummy404Handler);
     pipeline.addLast("protection", dummy404Handler);
     pipeline.addLast("proxy", dummy404Handler);
     pipeline.addLast("exception", new ExceptionHandler(metrics));

--- a/src/main/java/org/sensepitch/edge/Proxy.java
+++ b/src/main/java/org/sensepitch/edge/Proxy.java
@@ -245,7 +245,9 @@ public class Proxy implements ProxyContext {
     if (unservicedHost != null) {
       pipeline.addLast(unservicedHost.newHandler());
     }
+    ChannelHandler initialFallbackHandler = new FallbackHandler(FallbackConfig.DEFAULT.merge(config.fallback()));
     pipeline.addLast("siteSelector", new SiteSelectorHandler(siteSelector));
+    pipeline.addLast("fallback", initialFallbackHandler);
     pipeline.addLast("protection", dummy404Handler);
     pipeline.addLast("proxy", dummy404Handler);
     pipeline.addLast("exception", new ExceptionHandler(metrics));

--- a/src/main/java/org/sensepitch/edge/ProxyConfig.java
+++ b/src/main/java/org/sensepitch/edge/ProxyConfig.java
@@ -12,6 +12,7 @@ public record ProxyConfig(
     ListenConfig listen,
     UnservicedHostConfig unservicedHost,
     IpLookupConfig ipLookup,
+    FallbackConfig fallback,
     UpstreamConfig upstream,
     ProtectionConfig protection,
     Map<String, SiteConfig> sites) {}

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -4,19 +4,28 @@ import java.util.List;
 import lombok.Builder;
 
 /**
+ * A configured response, either a page or a redirect, never a mix of both:
+ *
+ * <ul>
+ *   <li>page: {@code text} (plain body) or {@code file} (see {@link Fallback} for how a file
+ *       location is resolved), with an optional {@code contentType} (default {@link
+ *       FallbackConfig#DEFAULT_CONTENT_TYPE}). Setting both {@code text} and {@code file} is
+ *       rejected.
+ *   <li>redirect: {@code location}, optionally with {@code status}
+ * </ul>
+ *
+ * @param status response status code, {@code 0} if unset. A redirect defaults to {@link
+ *     #DEFAULT_REDIRECT_STATUS} and must otherwise be one of {@link #REDIRECT_STATUS_CODES}. A page may
+ *     use any code in 100..599.
  * @author Jens Wilke
  */
 @Builder(toBuilder = true)
 public record ResponseConfig(
     String text, int status, String location, String contentType, String file) {
 
-  /**
-   * Status codes a redirect may use. Deliberately narrower than the whole 3xx range: 300, 304, 305
-   * and 306 are 3xx but are not redirects a {@code Location} header makes sense for.
-   */
-  private static final List<Integer> REDIRECT_CODES = List.of(301, 302, 303, 307, 308);
+  public static final List<Integer> REDIRECT_STATUS_CODES = List.of(301, 302, 303, 307, 308);
 
-  private static final int DEFAULT_REDIRECT_STATUS = 302;
+  public static final int DEFAULT_REDIRECT_STATUS = 302;
 
   public ResponseConfig {
     boolean isRedirect = location != null;
@@ -31,9 +40,9 @@ public record ResponseConfig(
     if (isRedirect) {
       if (status == 0) {
         status = DEFAULT_REDIRECT_STATUS;
-      } else if (!REDIRECT_CODES.contains(status)) {
+      } else if (!REDIRECT_STATUS_CODES.contains(status)) {
         throw new IllegalArgumentException(
-            "redirect status must be one of " + REDIRECT_CODES + ", was: " + status);
+            "redirect status must be one of " + REDIRECT_STATUS_CODES + ", was: " + status);
       }
     }
     if (text != null && file != null) {

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -2,6 +2,8 @@ package org.sensepitch.edge;
 
 import lombok.Builder;
 
+import java.util.List;
+
 /**
  * @author Jens Wilke
  */
@@ -10,49 +12,40 @@ public record ResponseConfig(
     String text,
     int status,
     String location,
-    String permanentRedirect,
-    String temporaryRedirect,
     String contentType,
     String file) {
+
   /**
-   * A response is exactly one of two kinds; setting fields from both is a misconfiguration:
-   *
-   * <ul>
-   *   <li><b>redirect</b>: {@code location} (or {@code permanentRedirect}/ {@code
-   *       temporaryRedirect}), no body
-   *   <li><b>page</b>: {@code text} or {@code file} (with optional {@code contentType})
-   * </ul>
+   * Status codes a redirect may use. Deliberately narrower than the whole 3xx range: 300, 304, 305
+   * and 306 are 3xx but are not redirects a {@code Location} header makes sense for.
    */
+  private static final List<Integer> REDIRECT_CODES = List.of(301, 302, 303, 307, 308);
+
+  private static final int DEFAULT_REDIRECT_STATUS = 302;
+
   public ResponseConfig {
-    boolean redirect = location != null || permanentRedirect != null || temporaryRedirect != null;
-    boolean page = text != null || file != null;
-    if (redirect && page) {
+    boolean isRedirect = location != null;
+    boolean hasPageBody = text != null || file != null;
+    if (isRedirect && hasPageBody || !isRedirect && !hasPageBody) {
       throw new IllegalArgumentException(
           """
-                            response is both a redirect and a page; use ONE of:
-                              redirect -> location (optionally with a 3xx status)
-                              page     -> text or file (optionally with an explicit status)""");
+          response should be one of:
+            redirect -> location (optionally with an explicit redirect status)
+            page     -> text or file (optionally with an explicit status)""");
     }
-    if (redirect && status != 0 && (status < 300 || status > 399)) {
-      throw new IllegalArgumentException("redirect status must be 3xx, was: " + status);
+    if (isRedirect) {
+      if (status == 0) {
+        status = DEFAULT_REDIRECT_STATUS;
+      } else if (!REDIRECT_CODES.contains(status)) {
+        throw new IllegalArgumentException(
+            "redirect status must be one of " + REDIRECT_CODES + ", was: " + status);
+      }
     }
     if (text != null && file != null) {
       throw new IllegalArgumentException("page is text OR file, not both");
     }
-  }
-
-  /**
-   * A resolved redirect.
-   *
-   * @param status 3xx status code
-   * @param location target URL for the {@code Location} header
-   */
-  public record Redirect(int status, String location) {}
-
-  public Redirect resolvedRedirect() {
-    if (permanentRedirect != null) return new Redirect(308, permanentRedirect);
-    if (temporaryRedirect != null) return new Redirect(307, temporaryRedirect);
-    if (location != null) return new Redirect(status != 0 ? status : 302, location);
-    return null;
+    if (status != 0 && (status < 100 || status > 599)) {
+      throw new IllegalArgumentException("status must be 100..599, was: " + status);
+    }
   }
 }

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -7,53 +7,49 @@ import lombok.Builder;
  */
 @Builder(toBuilder = true)
 public record ResponseConfig(
-        String text,
-        int status,
-        String location,
-        String permanentRedirect,
-        String temporaryRedirect,
-        String contentType,
-        String file
-) {
-    /**
-     * A response is exactly one of two kinds; setting fields from both is a misconfiguration:
-     * <ul>
-     *     <li><b>redirect</b>: {@code location} (or {@code permanentRedirect}/
-     *         {@code temporaryRedirect}), no body</li>
-     *     <li><b>page</b>: {@code text} or {@code file} (with optional {@code contentType})</li>
-     * </ul>
-     */
-    public ResponseConfig {
-        boolean redirect = location != null
-                || permanentRedirect != null
-                || temporaryRedirect != null;
-        boolean page = text != null || file != null;
-        if (redirect && page) {
-            throw new IllegalArgumentException(
-                    """
+    String text,
+    int status,
+    String location,
+    String permanentRedirect,
+    String temporaryRedirect,
+    String contentType,
+    String file) {
+  /**
+   * A response is exactly one of two kinds; setting fields from both is a misconfiguration:
+   *
+   * <ul>
+   *   <li><b>redirect</b>: {@code location} (or {@code permanentRedirect}/ {@code
+   *       temporaryRedirect}), no body
+   *   <li><b>page</b>: {@code text} or {@code file} (with optional {@code contentType})
+   * </ul>
+   */
+  public ResponseConfig {
+    boolean redirect = location != null || permanentRedirect != null || temporaryRedirect != null;
+    boolean page = text != null || file != null;
+    if (redirect && page) {
+      throw new IllegalArgumentException(
+          """
                             response is both a redirect and a page; use ONE of:
                               redirect -> location (optionally with a 3xx status)
                               page     -> text or file (optionally with an explicit status)""");
-        }
-        if (redirect && status != 0 && (status < 300 || status > 399)) {
-            throw new IllegalArgumentException(
-                    "redirect status must be 3xx, was: " + status);
-        }
     }
+    if (redirect && status != 0 && (status < 300 || status > 399)) {
+      throw new IllegalArgumentException("redirect status must be 3xx, was: " + status);
+    }
+  }
 
-    /**
-     * A resolved redirect.
-     *
-     * @param status 3xx status code
-     * @param location target URL for the {@code Location} header
-     */
-    public record Redirect(int status, String location) {
-    }
+  /**
+   * A resolved redirect.
+   *
+   * @param status 3xx status code
+   * @param location target URL for the {@code Location} header
+   */
+  public record Redirect(int status, String location) {}
 
-    public Redirect resolvedRedirect() {
-        if (permanentRedirect != null) return new Redirect(308, permanentRedirect);
-        if (temporaryRedirect != null) return new Redirect(307, temporaryRedirect);
-        if (location != null) return new Redirect(status != 0 ? status : 302, location);
-        return null;
-    }
+  public Redirect resolvedRedirect() {
+    if (permanentRedirect != null) return new Redirect(308, permanentRedirect);
+    if (temporaryRedirect != null) return new Redirect(307, temporaryRedirect);
+    if (location != null) return new Redirect(status != 0 ? status : 302, location);
+    return null;
+  }
 }

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -22,9 +22,6 @@ public record ResponseConfig(
      *         {@code temporaryRedirect}), no body</li>
      *     <li><b>page</b>: {@code text} or {@code file} (with optional {@code contentType})</li>
      * </ul>
-     * {@code status} is neutral: it sets the response code for either kind (a page may carry an
-     * explicit status, e.g. {@code status: 503} with a body), so it is not a redirect signal.
-     * {@code location} (or the redirect aliases) is the sole discriminator.
      */
     public ResponseConfig {
         boolean redirect = location != null

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -1,19 +1,14 @@
 package org.sensepitch.edge;
 
-import lombok.Builder;
-
 import java.util.List;
+import lombok.Builder;
 
 /**
  * @author Jens Wilke
  */
 @Builder(toBuilder = true)
 public record ResponseConfig(
-    String text,
-    int status,
-    String location,
-    String contentType,
-    String file) {
+    String text, int status, String location, String contentType, String file) {
 
   /**
    * Status codes a redirect may use. Deliberately narrower than the whole 3xx range: 300, 304, 305

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -35,6 +35,10 @@ public record ResponseConfig(
                               redirect -> location (optionally with a 3xx status)
                               page     -> text or file (optionally with an explicit status)""");
         }
+        if (redirect && status != 0 && (status < 300 || status > 399)) {
+            throw new IllegalArgumentException(
+                    "redirect status must be 3xx, was: " + status);
+        }
     }
 
     /**

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -36,6 +36,9 @@ public record ResponseConfig(
     if (redirect && status != 0 && (status < 300 || status > 399)) {
       throw new IllegalArgumentException("redirect status must be 3xx, was: " + status);
     }
+    if (text != null && file != null) {
+      throw new IllegalArgumentException("page is text OR file, not both");
+    }
   }
 
   /**

--- a/src/main/java/org/sensepitch/edge/ResponseConfig.java
+++ b/src/main/java/org/sensepitch/edge/ResponseConfig.java
@@ -7,4 +7,52 @@ import lombok.Builder;
  */
 @Builder(toBuilder = true)
 public record ResponseConfig(
-    String text, int status, String location, String permanentRedirect, String temporaryRedirect) {}
+        String text,
+        int status,
+        String location,
+        String permanentRedirect,
+        String temporaryRedirect,
+        String contentType,
+        String file
+) {
+    /**
+     * A response is exactly one of two kinds; setting fields from both is a misconfiguration:
+     * <ul>
+     *     <li><b>redirect</b>: {@code location} (or {@code permanentRedirect}/
+     *         {@code temporaryRedirect}), no body</li>
+     *     <li><b>page</b>: {@code text} or {@code file} (with optional {@code contentType})</li>
+     * </ul>
+     * {@code status} is neutral: it sets the response code for either kind (a page may carry an
+     * explicit status, e.g. {@code status: 503} with a body), so it is not a redirect signal.
+     * {@code location} (or the redirect aliases) is the sole discriminator.
+     */
+    public ResponseConfig {
+        boolean redirect = location != null
+                || permanentRedirect != null
+                || temporaryRedirect != null;
+        boolean page = text != null || file != null;
+        if (redirect && page) {
+            throw new IllegalArgumentException(
+                    """
+                            response is both a redirect and a page; use ONE of:
+                              redirect -> location (optionally with a 3xx status)
+                              page     -> text or file (optionally with an explicit status)""");
+        }
+    }
+
+    /**
+     * A resolved redirect.
+     *
+     * @param status 3xx status code
+     * @param location target URL for the {@code Location} header
+     */
+    public record Redirect(int status, String location) {
+    }
+
+    public Redirect resolvedRedirect() {
+        if (permanentRedirect != null) return new Redirect(308, permanentRedirect);
+        if (temporaryRedirect != null) return new Redirect(307, temporaryRedirect);
+        if (location != null) return new Redirect(status != 0 ? status : 302, location);
+        return null;
+    }
+}

--- a/src/main/java/org/sensepitch/edge/SiteConfig.java
+++ b/src/main/java/org/sensepitch/edge/SiteConfig.java
@@ -11,6 +11,7 @@ public record SiteConfig(
     String host,
     String uri,
     ResponseConfig response,
+    FallbackConfig fallback,
     UpstreamConfig upstream,
     ProtectionConfig protection)
     implements HasKey {}

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -87,7 +87,7 @@ public class SiteSelector {
     }
 
     private Supplier<ChannelHandler> constructFallbackSupplier(FallbackConfig globalFallback, FallbackConfig siteFallback) {
-        FallbackConfig config = FallbackConfig.DEFAULT.merge(globalFallback).merge(siteFallback);
+        FallbackConfig config = FallbackConfig.DEFAULTS.merge(globalFallback).merge(siteFallback);
         FallbackHandler handler = new FallbackHandler(config);
 
         return () -> handler;

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -17,7 +17,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,181 +30,181 @@ import java.util.function.Supplier;
  */
 public class SiteSelector {
 
-    private static final SiteConfig SITE_CONFIG_DEFAULT = SiteConfig.builder().build();
-    private final Upstream defaultUpstream;
-    private final Map<String, Suppliers> directHostMatch = new HashMap<>();
-    private final Map<String, TreeMap<String, Suppliers>> sitePrefixUriMatch = new HashMap<>();
+  private static final SiteConfig SITE_CONFIG_DEFAULT = SiteConfig.builder().build();
+  private final Upstream defaultUpstream;
+  private final Map<String, Suppliers> directHostMatch = new HashMap<>();
+  private final Map<String, TreeMap<String, Suppliers>> sitePrefixUriMatch = new HashMap<>();
 
-    public SiteSelector(ProxyContext ctx, ProxyConfig config) {
-        if (config.sites() == null || config.sites().isEmpty()) {
-            throw new IllegalArgumentException("sites missing");
-        }
-        if (config.upstream() != null) {
-            defaultUpstream = constructUpstream(ctx, config.upstream());
+  public SiteSelector(ProxyContext ctx, ProxyConfig config) {
+    if (config.sites() == null || config.sites().isEmpty()) {
+      throw new IllegalArgumentException("sites missing");
+    }
+    if (config.upstream() != null) {
+      defaultUpstream = constructUpstream(ctx, config.upstream());
+    } else {
+      defaultUpstream = null;
+    }
+    config
+        .sites()
+        .values()
+        .forEach(
+            site -> {
+              Supplier<ChannelHandler> fallbackSupplier =
+                  constructFallbackSupplier(config.fallback(), site.fallback());
+              Supplier<ChannelHandler> proxySupplier = constructProxySupplier(ctx, site);
+              Supplier<ChannelHandler> protectionSupplier = null;
+              ProtectionConfig protection = site.protection();
+              if (protection == null) {
+                protection = config.protection();
+              }
+              protectionSupplier = Protection.handlerSupplier(protection);
+              if (protectionSupplier == null) {
+                throw new IllegalArgumentException(
+                    "Site requires protection scheme or explicit disable");
+              }
+              var suppliers = new Suppliers(fallbackSupplier, protectionSupplier, proxySupplier);
+              String host = site.host();
+              if (host == null) {
+                host = site.key();
+              }
+              if (host == null) {
+                throw new IllegalArgumentException("Site requires host or key");
+              }
+              if (host.contains("*")) {
+                // TODO: support wildcard hosts
+                throw new IllegalArgumentException("Host wildcards are not yet supported");
+              }
+              if (site.uri() == null || site.uri().equals("*") || site.uri().equals("/*")) {
+                directHostMatch.put(host, suppliers);
+              } else if (site.uri().endsWith("*")) {
+                String matchUri = site.uri().substring(0, site.uri().length() - 1);
+                var tree = sitePrefixUriMatch.computeIfAbsent(host, k -> new TreeMap<>());
+                tree.put(matchUri, suppliers);
+              } else {
+                throw new IllegalArgumentException("Site match uri needs to be prefix");
+              }
+            });
+  }
+
+  private Supplier<ChannelHandler> constructFallbackSupplier(
+      FallbackConfig globalFallback, FallbackConfig siteFallback) {
+    FallbackConfig config = FallbackConfig.DEFAULTS.merge(globalFallback).merge(siteFallback);
+    FallbackHandler handler = new FallbackHandler(config);
+
+    return () -> handler;
+  }
+
+  private Supplier<ChannelHandler> constructProxySupplier(ProxyContext ctx, SiteConfig site) {
+    Upstream upstream;
+    if (site.response() != null) {
+      ResponseConfig response = site.response();
+      HttpResponseStatus status;
+      String location;
+      if (response.permanentRedirect() != null) {
+        location = response.permanentRedirect();
+        status = HttpResponseStatus.PERMANENT_REDIRECT;
+      } else if (response.temporaryRedirect() != null) {
+        location = response.temporaryRedirect();
+        status = HttpResponseStatus.TEMPORARY_REDIRECT;
+      } else if (response.location() != null) {
+        location = response.location();
+        if (response.status() != 0) {
+          status = HttpResponseStatus.valueOf(response.status());
         } else {
-            defaultUpstream = null;
+          status = HttpResponseStatus.FOUND;
         }
-        config
-                .sites()
-                .values()
-                .forEach(
-                        site -> {
-                            Supplier<ChannelHandler> fallbackSupplier = constructFallbackSupplier(config.fallback(), site.fallback());
-                            Supplier<ChannelHandler> proxySupplier = constructProxySupplier(ctx, site);
-                            Supplier<ChannelHandler> protectionSupplier = null;
-                            ProtectionConfig protection = site.protection();
-                            if (protection == null) {
-                                protection = config.protection();
-                            }
-                            protectionSupplier = Protection.handlerSupplier(protection);
-                            if (protectionSupplier == null) {
-                                throw new IllegalArgumentException(
-                                        "Site requires protection scheme or explicit disable");
-                            }
-                            var suppliers = new Suppliers(fallbackSupplier, protectionSupplier, proxySupplier);
-                            String host = site.host();
-                            if (host == null) {
-                                host = site.key();
-                            }
-                            if (host == null) {
-                                throw new IllegalArgumentException("Site requires host or key");
-                            }
-                            if (host.contains("*")) {
-                                // TODO: support wildcard hosts
-                                throw new IllegalArgumentException("Host wildcards are not yet supported");
-                            }
-                            if (site.uri() == null || site.uri().equals("*") || site.uri().equals("/*")) {
-                                directHostMatch.put(host, suppliers);
-                            } else if (site.uri().endsWith("*")) {
-                                String matchUri = site.uri().substring(0, site.uri().length() - 1);
-                                var tree = sitePrefixUriMatch.computeIfAbsent(host, k -> new TreeMap<>());
-                                tree.put(matchUri, suppliers);
-                            } else {
-                                throw new IllegalArgumentException("Site match uri needs to be prefix");
-                            }
-                        });
-    }
-
-    private Supplier<ChannelHandler> constructFallbackSupplier(FallbackConfig globalFallback, FallbackConfig siteFallback) {
-        FallbackConfig config = FallbackConfig.DEFAULTS.merge(globalFallback).merge(siteFallback);
-        FallbackHandler handler = new FallbackHandler(config);
-
-        return () -> handler;
-    }
-
-    private Supplier<ChannelHandler> constructProxySupplier(ProxyContext ctx, SiteConfig site) {
-        Upstream upstream;
-        if (site.response() != null) {
-            ResponseConfig response = site.response();
-            HttpResponseStatus status;
-            String location;
-            if (response.permanentRedirect() != null) {
-                location = response.permanentRedirect();
-                status = HttpResponseStatus.PERMANENT_REDIRECT;
-            } else if (response.temporaryRedirect() != null) {
-                location = response.temporaryRedirect();
-                status = HttpResponseStatus.TEMPORARY_REDIRECT;
-            } else if (response.location() != null) {
-                location = response.location();
-                if (response.status() != 0) {
-                    status = HttpResponseStatus.valueOf(response.status());
-                } else {
-                    status = HttpResponseStatus.FOUND;
-                }
-            } else {
-                location = null;
-                if (response.status() != 0) {
-                    status = HttpResponseStatus.valueOf(response.status());
-                } else {
-                    status = HttpResponseStatus.OK;
-                }
-            }
-            String text = response.text();
-            if (text == null && location == null) {
-                throw new IllegalArgumentException("Response requires redirect location or text");
-            }
-            upstream =
-                    new Upstream() {
-                        @Override
-                        public Future<Channel> connect(ChannelHandlerContext ingressContext) {
-                            Promise<Channel> promise = ingressContext.executor().newPromise();
-                            Channel ingressChannel = ingressContext.channel();
-                            Channel upstreamChannel =
-                                    EmbeddedChannel.builder()
-                                            .handlers(
-                                                    new ChannelOutboundHandlerAdapter() {
-                                                        @Override
-                                                        public void write(
-                                                                ChannelHandlerContext ctx1, Object msg, ChannelPromise promise) {
-                                                            if (msg instanceof HttpRequest) {
-                                                                ByteBuf content = Unpooled.EMPTY_BUFFER;
-                                                                if (text != null) {
-                                                                    content = Unpooled.copiedBuffer(text, StandardCharsets.US_ASCII);
-                                                                }
-                                                                FullHttpResponse response =
-                                                                        new DefaultFullHttpResponse(
-                                                                                HttpVersion.HTTP_1_1, status, content);
-                                                                response
-                                                                        .headers()
-                                                                        .set(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
-                                                                if (location != null) {
-                                                                    response.headers().set(HttpHeaderNames.LOCATION, location);
-                                                                }
-                                                                ingressChannel.writeAndFlush(response);
-                                                            }
-                                                            ReferenceCountUtil.release(msg);
-                                                        }
-                                                    })
-                                            .build();
-                            promise.setSuccess(upstreamChannel);
-                            return promise;
-                        }
-
-                        @Override
-                        public void release(Channel ch) {
-                            // ignore, embedded
-                        }
-                    };
-        } else if (site.upstream() != null) {
-            upstream = constructUpstream(ctx, site.upstream());
-        } else if (defaultUpstream != null) {
-            upstream = defaultUpstream;
+      } else {
+        location = null;
+        if (response.status() != 0) {
+          status = HttpResponseStatus.valueOf(response.status());
         } else {
-            throw new IllegalArgumentException("upstream missing");
+          status = HttpResponseStatus.OK;
         }
-        Supplier<ChannelHandler> proxySupplier = () -> new DownstreamHandler(upstream, ctx.metrics());
-        return proxySupplier;
-    }
-
-    private static DefaultUpstream constructUpstream(ProxyContext ctx, UpstreamConfig cfg) {
-        return new DefaultUpstream(ctx, cfg);
-    }
-
-    public Set<String> getServicedHosts() {
-        Set<String> hosts = new HashSet<>();
-        hosts.addAll(directHostMatch.keySet());
-        hosts.addAll(sitePrefixUriMatch.keySet());
-        return hosts;
-    }
-
-    public Suppliers getSuppliers(HttpRequest request, String host) {
-        var suppliers = directHostMatch.get(host);
-        if (suppliers == null) {
-            var tree = sitePrefixUriMatch.get(host);
-            if (tree != null) {
-                var entry = tree.floorEntry(request.uri());
-                if (entry != null && request.uri().startsWith(entry.getKey())) {
-                    suppliers = entry.getValue();
-                }
+      }
+      String text = response.text();
+      if (text == null && location == null) {
+        throw new IllegalArgumentException("Response requires redirect location or text");
+      }
+      upstream =
+          new Upstream() {
+            @Override
+            public Future<Channel> connect(ChannelHandlerContext ingressContext) {
+              Promise<Channel> promise = ingressContext.executor().newPromise();
+              Channel ingressChannel = ingressContext.channel();
+              Channel upstreamChannel =
+                  EmbeddedChannel.builder()
+                      .handlers(
+                          new ChannelOutboundHandlerAdapter() {
+                            @Override
+                            public void write(
+                                ChannelHandlerContext ctx1, Object msg, ChannelPromise promise) {
+                              if (msg instanceof HttpRequest) {
+                                ByteBuf content = Unpooled.EMPTY_BUFFER;
+                                if (text != null) {
+                                  content = Unpooled.copiedBuffer(text, StandardCharsets.US_ASCII);
+                                }
+                                FullHttpResponse response =
+                                    new DefaultFullHttpResponse(
+                                        HttpVersion.HTTP_1_1, status, content);
+                                response
+                                    .headers()
+                                    .set(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+                                if (location != null) {
+                                  response.headers().set(HttpHeaderNames.LOCATION, location);
+                                }
+                                ingressChannel.writeAndFlush(response);
+                              }
+                              ReferenceCountUtil.release(msg);
+                            }
+                          })
+                      .build();
+              promise.setSuccess(upstreamChannel);
+              return promise;
             }
-        }
-        return suppliers;
-    }
 
-    record Suppliers(
-            Supplier<ChannelHandler> fallbackSupplier,
-            Supplier<ChannelHandler> protectionSupplier,
-            Supplier<ChannelHandler> proxySupplier
-    ) {
+            @Override
+            public void release(Channel ch) {
+              // ignore, embedded
+            }
+          };
+    } else if (site.upstream() != null) {
+      upstream = constructUpstream(ctx, site.upstream());
+    } else if (defaultUpstream != null) {
+      upstream = defaultUpstream;
+    } else {
+      throw new IllegalArgumentException("upstream missing");
     }
+    Supplier<ChannelHandler> proxySupplier = () -> new DownstreamHandler(upstream, ctx.metrics());
+    return proxySupplier;
+  }
+
+  private static DefaultUpstream constructUpstream(ProxyContext ctx, UpstreamConfig cfg) {
+    return new DefaultUpstream(ctx, cfg);
+  }
+
+  public Set<String> getServicedHosts() {
+    Set<String> hosts = new HashSet<>();
+    hosts.addAll(directHostMatch.keySet());
+    hosts.addAll(sitePrefixUriMatch.keySet());
+    return hosts;
+  }
+
+  public Suppliers getSuppliers(HttpRequest request, String host) {
+    var suppliers = directHostMatch.get(host);
+    if (suppliers == null) {
+      var tree = sitePrefixUriMatch.get(host);
+      if (tree != null) {
+        var entry = tree.floorEntry(request.uri());
+        if (entry != null && request.uri().startsWith(entry.getKey())) {
+          suppliers = entry.getValue();
+        }
+      }
+    }
+    return suppliers;
+  }
+
+  record Suppliers(
+      Supplier<ChannelHandler> fallbackSupplier,
+      Supplier<ChannelHandler> protectionSupplier,
+      Supplier<ChannelHandler> proxySupplier) {}
 }

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -17,6 +17,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,169 +31,181 @@ import java.util.function.Supplier;
  */
 public class SiteSelector {
 
-  private static final SiteConfig SITE_CONFIG_DEFAULT = SiteConfig.builder().build();
-  private final Upstream defaultUpstream;
-  private final Map<String, Suppliers> directHostMatch = new HashMap<>();
-  private final Map<String, TreeMap<String, Suppliers>> sitePrefixUriMatch = new HashMap<>();
+    private static final SiteConfig SITE_CONFIG_DEFAULT = SiteConfig.builder().build();
+    private final Upstream defaultUpstream;
+    private final Map<String, Suppliers> directHostMatch = new HashMap<>();
+    private final Map<String, TreeMap<String, Suppliers>> sitePrefixUriMatch = new HashMap<>();
 
-  public SiteSelector(ProxyContext ctx, ProxyConfig config) {
-    if (config.sites() == null || config.sites().isEmpty()) {
-      throw new IllegalArgumentException("sites missing");
-    }
-    if (config.upstream() != null) {
-      defaultUpstream = constructUpstream(ctx, config.upstream());
-    } else {
-      defaultUpstream = null;
-    }
-    config
-        .sites()
-        .values()
-        .forEach(
-            site -> {
-              Supplier<ChannelHandler> proxySupplier = constructProxySupplier(ctx, site);
-              Supplier<ChannelHandler> protectionSupplier = null;
-              ProtectionConfig protection = site.protection();
-              if (protection == null) {
-                protection = config.protection();
-              }
-              protectionSupplier = Protection.handlerSupplier(protection);
-              if (protectionSupplier == null) {
-                throw new IllegalArgumentException(
-                    "Site requires protection scheme or explicit disable");
-              }
-              var suppliers = new Suppliers(protectionSupplier, proxySupplier);
-              String host = site.host();
-              if (host == null) {
-                host = site.key();
-              }
-              if (host == null) {
-                throw new IllegalArgumentException("Site requires host or key");
-              }
-              if (host.contains("*")) {
-                // TODO: support wildcard hosts
-                throw new IllegalArgumentException("Host wildcards are not yet supported");
-              }
-              if (site.uri() == null || site.uri().equals("*") || site.uri().equals("/*")) {
-                directHostMatch.put(host, suppliers);
-              } else if (site.uri().endsWith("*")) {
-                String matchUri = site.uri().substring(0, site.uri().length() - 1);
-                var tree = sitePrefixUriMatch.computeIfAbsent(host, k -> new TreeMap<>());
-                tree.put(matchUri, suppliers);
-              } else {
-                throw new IllegalArgumentException("Site match uri needs to be prefix");
-              }
-            });
-  }
-
-  private Supplier<ChannelHandler> constructProxySupplier(ProxyContext ctx, SiteConfig site) {
-    Upstream upstream;
-    if (site.response() != null) {
-      ResponseConfig response = site.response();
-      HttpResponseStatus status;
-      String location;
-      if (response.permanentRedirect() != null) {
-        location = response.permanentRedirect();
-        status = HttpResponseStatus.PERMANENT_REDIRECT;
-      } else if (response.temporaryRedirect() != null) {
-        location = response.temporaryRedirect();
-        status = HttpResponseStatus.TEMPORARY_REDIRECT;
-      } else if (response.location() != null) {
-        location = response.location();
-        if (response.status() != 0) {
-          status = HttpResponseStatus.valueOf(response.status());
-        } else {
-          status = HttpResponseStatus.FOUND;
+    public SiteSelector(ProxyContext ctx, ProxyConfig config) {
+        if (config.sites() == null || config.sites().isEmpty()) {
+            throw new IllegalArgumentException("sites missing");
         }
-      } else {
-        location = null;
-        if (response.status() != 0) {
-          status = HttpResponseStatus.valueOf(response.status());
+        if (config.upstream() != null) {
+            defaultUpstream = constructUpstream(ctx, config.upstream());
         } else {
-          status = HttpResponseStatus.OK;
+            defaultUpstream = null;
         }
-      }
-      String text = response.text();
-      if (text == null && location == null) {
-        throw new IllegalArgumentException("Response requires redirect location or text");
-      }
-      upstream =
-          new Upstream() {
-            @Override
-            public Future<Channel> connect(ChannelHandlerContext ingressContext) {
-              Promise<Channel> promise = ingressContext.executor().newPromise();
-              Channel ingressChannel = ingressContext.channel();
-              Channel upstreamChannel =
-                  EmbeddedChannel.builder()
-                      .handlers(
-                          new ChannelOutboundHandlerAdapter() {
-                            @Override
-                            public void write(
-                                ChannelHandlerContext ctx1, Object msg, ChannelPromise promise) {
-                              if (msg instanceof HttpRequest) {
-                                ByteBuf content = Unpooled.EMPTY_BUFFER;
-                                if (text != null) {
-                                  content = Unpooled.copiedBuffer(text, StandardCharsets.US_ASCII);
-                                }
-                                FullHttpResponse response =
-                                    new DefaultFullHttpResponse(
-                                        HttpVersion.HTTP_1_1, status, content);
-                                response
-                                    .headers()
-                                    .set(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
-                                if (location != null) {
-                                  response.headers().set(HttpHeaderNames.LOCATION, location);
-                                }
-                                ingressChannel.writeAndFlush(response);
-                              }
-                              ReferenceCountUtil.release(msg);
+        config
+                .sites()
+                .values()
+                .forEach(
+                        site -> {
+                            Supplier<ChannelHandler> fallbackSupplier = constructFallbackSupplier(config.fallback(), site.fallback());
+                            Supplier<ChannelHandler> proxySupplier = constructProxySupplier(ctx, site);
+                            Supplier<ChannelHandler> protectionSupplier = null;
+                            ProtectionConfig protection = site.protection();
+                            if (protection == null) {
+                                protection = config.protection();
                             }
-                          })
-                      .build();
-              promise.setSuccess(upstreamChannel);
-              return promise;
-            }
-
-            @Override
-            public void release(Channel ch) {
-              // ignore, embedded
-            }
-          };
-    } else if (site.upstream() != null) {
-      upstream = constructUpstream(ctx, site.upstream());
-    } else if (defaultUpstream != null) {
-      upstream = defaultUpstream;
-    } else {
-      throw new IllegalArgumentException("upstream missing");
+                            protectionSupplier = Protection.handlerSupplier(protection);
+                            if (protectionSupplier == null) {
+                                throw new IllegalArgumentException(
+                                        "Site requires protection scheme or explicit disable");
+                            }
+                            var suppliers = new Suppliers(fallbackSupplier, protectionSupplier, proxySupplier);
+                            String host = site.host();
+                            if (host == null) {
+                                host = site.key();
+                            }
+                            if (host == null) {
+                                throw new IllegalArgumentException("Site requires host or key");
+                            }
+                            if (host.contains("*")) {
+                                // TODO: support wildcard hosts
+                                throw new IllegalArgumentException("Host wildcards are not yet supported");
+                            }
+                            if (site.uri() == null || site.uri().equals("*") || site.uri().equals("/*")) {
+                                directHostMatch.put(host, suppliers);
+                            } else if (site.uri().endsWith("*")) {
+                                String matchUri = site.uri().substring(0, site.uri().length() - 1);
+                                var tree = sitePrefixUriMatch.computeIfAbsent(host, k -> new TreeMap<>());
+                                tree.put(matchUri, suppliers);
+                            } else {
+                                throw new IllegalArgumentException("Site match uri needs to be prefix");
+                            }
+                        });
     }
-    Supplier<ChannelHandler> proxySupplier = () -> new DownstreamHandler(upstream, ctx.metrics());
-    return proxySupplier;
-  }
 
-  private static DefaultUpstream constructUpstream(ProxyContext ctx, UpstreamConfig cfg) {
-    return new DefaultUpstream(ctx, cfg);
-  }
+    private Supplier<ChannelHandler> constructFallbackSupplier(FallbackConfig globalFallback, FallbackConfig siteFallback) {
+        FallbackConfig config = FallbackConfig.DEFAULT.merge(globalFallback).merge(siteFallback);
+        FallbackHandler handler = new FallbackHandler(config);
 
-  public Set<String> getServicedHosts() {
-    Set<String> hosts = new HashSet<>();
-    hosts.addAll(directHostMatch.keySet());
-    hosts.addAll(sitePrefixUriMatch.keySet());
-    return hosts;
-  }
+        return () -> handler;
+    }
 
-  public Suppliers getSuppliers(HttpRequest request, String host) {
-    var suppliers = directHostMatch.get(host);
-    if (suppliers == null) {
-      var tree = sitePrefixUriMatch.get(host);
-      if (tree != null) {
-        var entry = tree.floorEntry(request.uri());
-        if (entry != null && request.uri().startsWith(entry.getKey())) {
-          suppliers = entry.getValue();
+    private Supplier<ChannelHandler> constructProxySupplier(ProxyContext ctx, SiteConfig site) {
+        Upstream upstream;
+        if (site.response() != null) {
+            ResponseConfig response = site.response();
+            HttpResponseStatus status;
+            String location;
+            if (response.permanentRedirect() != null) {
+                location = response.permanentRedirect();
+                status = HttpResponseStatus.PERMANENT_REDIRECT;
+            } else if (response.temporaryRedirect() != null) {
+                location = response.temporaryRedirect();
+                status = HttpResponseStatus.TEMPORARY_REDIRECT;
+            } else if (response.location() != null) {
+                location = response.location();
+                if (response.status() != 0) {
+                    status = HttpResponseStatus.valueOf(response.status());
+                } else {
+                    status = HttpResponseStatus.FOUND;
+                }
+            } else {
+                location = null;
+                if (response.status() != 0) {
+                    status = HttpResponseStatus.valueOf(response.status());
+                } else {
+                    status = HttpResponseStatus.OK;
+                }
+            }
+            String text = response.text();
+            if (text == null && location == null) {
+                throw new IllegalArgumentException("Response requires redirect location or text");
+            }
+            upstream =
+                    new Upstream() {
+                        @Override
+                        public Future<Channel> connect(ChannelHandlerContext ingressContext) {
+                            Promise<Channel> promise = ingressContext.executor().newPromise();
+                            Channel ingressChannel = ingressContext.channel();
+                            Channel upstreamChannel =
+                                    EmbeddedChannel.builder()
+                                            .handlers(
+                                                    new ChannelOutboundHandlerAdapter() {
+                                                        @Override
+                                                        public void write(
+                                                                ChannelHandlerContext ctx1, Object msg, ChannelPromise promise) {
+                                                            if (msg instanceof HttpRequest) {
+                                                                ByteBuf content = Unpooled.EMPTY_BUFFER;
+                                                                if (text != null) {
+                                                                    content = Unpooled.copiedBuffer(text, StandardCharsets.US_ASCII);
+                                                                }
+                                                                FullHttpResponse response =
+                                                                        new DefaultFullHttpResponse(
+                                                                                HttpVersion.HTTP_1_1, status, content);
+                                                                response
+                                                                        .headers()
+                                                                        .set(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+                                                                if (location != null) {
+                                                                    response.headers().set(HttpHeaderNames.LOCATION, location);
+                                                                }
+                                                                ingressChannel.writeAndFlush(response);
+                                                            }
+                                                            ReferenceCountUtil.release(msg);
+                                                        }
+                                                    })
+                                            .build();
+                            promise.setSuccess(upstreamChannel);
+                            return promise;
+                        }
+
+                        @Override
+                        public void release(Channel ch) {
+                            // ignore, embedded
+                        }
+                    };
+        } else if (site.upstream() != null) {
+            upstream = constructUpstream(ctx, site.upstream());
+        } else if (defaultUpstream != null) {
+            upstream = defaultUpstream;
+        } else {
+            throw new IllegalArgumentException("upstream missing");
         }
-      }
+        Supplier<ChannelHandler> proxySupplier = () -> new DownstreamHandler(upstream, ctx.metrics());
+        return proxySupplier;
     }
-    return suppliers;
-  }
 
-  record Suppliers(
-      Supplier<ChannelHandler> protectionSupplier, Supplier<ChannelHandler> proxySupplier) {}
+    private static DefaultUpstream constructUpstream(ProxyContext ctx, UpstreamConfig cfg) {
+        return new DefaultUpstream(ctx, cfg);
+    }
+
+    public Set<String> getServicedHosts() {
+        Set<String> hosts = new HashSet<>();
+        hosts.addAll(directHostMatch.keySet());
+        hosts.addAll(sitePrefixUriMatch.keySet());
+        return hosts;
+    }
+
+    public Suppliers getSuppliers(HttpRequest request, String host) {
+        var suppliers = directHostMatch.get(host);
+        if (suppliers == null) {
+            var tree = sitePrefixUriMatch.get(host);
+            if (tree != null) {
+                var entry = tree.floorEntry(request.uri());
+                if (entry != null && request.uri().startsWith(entry.getKey())) {
+                    suppliers = entry.getValue();
+                }
+            }
+        }
+        return suppliers;
+    }
+
+    record Suppliers(
+            Supplier<ChannelHandler> fallbackSupplier,
+            Supplier<ChannelHandler> protectionSupplier,
+            Supplier<ChannelHandler> proxySupplier
+    ) {
+    }
 }

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -87,11 +87,10 @@ public class SiteSelector {
   }
 
   private Supplier<ChannelHandler> constructFallbackSupplier(
-      FallbackConfig globalFallback, FallbackConfig siteFallback) {
-    FallbackConfig config = FallbackConfig.DEFAULTS.merge(globalFallback).merge(siteFallback);
-    FallbackHandler handler = new FallbackHandler(config);
+      FallbackConfig global, FallbackConfig site) {
+    Fallback fallback = new Fallback(FallbackConfig.DEFAULTS.merge(global).merge(site));
 
-    return () -> handler;
+    return () -> fallback.newHandler();
   }
 
   private Supplier<ChannelHandler> constructProxySupplier(ProxyContext ctx, SiteConfig site) {

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -99,7 +99,7 @@ public class SiteSelector {
       ResponseConfig response = site.response();
       HttpResponseStatus status;
       String location;
-        if (response.location() != null) {
+      if (response.location() != null) {
         location = response.location();
         if (response.status() != 0) {
           status = HttpResponseStatus.valueOf(response.status());

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -97,15 +97,10 @@ public class SiteSelector {
     Upstream upstream;
     if (site.response() != null) {
       ResponseConfig response = site.response();
-      HttpResponseStatus status;
+      HttpResponseStatus status = HttpResponseStatus.valueOf(response.status());
       String location;
       if (response.location() != null) {
         location = response.location();
-        if (response.status() != 0) {
-          status = HttpResponseStatus.valueOf(response.status());
-        } else {
-          status = HttpResponseStatus.FOUND;
-        }
       } else {
         location = null;
         if (response.status() != 0) {
@@ -118,6 +113,8 @@ public class SiteSelector {
       if (text == null && location == null) {
         throw new IllegalArgumentException("Response requires redirect location or text");
       }
+      // status is reassigned above, so capture an effectively final copy for the anonymous upstream
+      HttpResponseStatus finalStatus = status;
       upstream =
           new Upstream() {
             @Override
@@ -138,7 +135,7 @@ public class SiteSelector {
                                 }
                                 FullHttpResponse response =
                                     new DefaultFullHttpResponse(
-                                        HttpVersion.HTTP_1_1, status, content);
+                                        HttpVersion.HTTP_1_1, finalStatus, content);
                                 response
                                     .headers()
                                     .set(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());

--- a/src/main/java/org/sensepitch/edge/SiteSelector.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelector.java
@@ -99,13 +99,7 @@ public class SiteSelector {
       ResponseConfig response = site.response();
       HttpResponseStatus status;
       String location;
-      if (response.permanentRedirect() != null) {
-        location = response.permanentRedirect();
-        status = HttpResponseStatus.PERMANENT_REDIRECT;
-      } else if (response.temporaryRedirect() != null) {
-        location = response.temporaryRedirect();
-        status = HttpResponseStatus.TEMPORARY_REDIRECT;
-      } else if (response.location() != null) {
+        if (response.location() != null) {
         location = response.location();
         if (response.status() != 0) {
           status = HttpResponseStatus.valueOf(response.status());

--- a/src/main/java/org/sensepitch/edge/SiteSelectorHandler.java
+++ b/src/main/java/org/sensepitch/edge/SiteSelectorHandler.java
@@ -26,8 +26,11 @@ public class SiteSelectorHandler extends SkippingChannelInboundHandlerAdapter {
         rejectRequest(ctx, HttpResponseStatus.NOT_FOUND);
         return;
       }
+      ChannelHandler fallback = suppliers.fallbackSupplier().get();
       ChannelHandler protection = suppliers.protectionSupplier().get();
       ChannelHandler proxy = suppliers.proxySupplier().get();
+
+      ctx.pipeline().replace("fallback", "fallback", fallback);
       ctx.pipeline().replace("protection", "protection", protection);
       ctx.pipeline().replace("proxy", "proxy", proxy);
     }

--- a/src/main/resources/fallback/error.html
+++ b/src/main/resources/fallback/error.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Internal Server Error</title>
+</head>
+<body style="font-family: system-ui, sans-serif; text-align: center; margin-top: 15%;">
+  <h1>500 Internal Server Error</h1>
+  <p>Something went wrong on our end. Please try again later.</p>
+</body>
+</html>

--- a/src/main/resources/fallback/unavailable.html
+++ b/src/main/resources/fallback/unavailable.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Service Unavailable</title>
+</head>
+<body style="font-family: system-ui, sans-serif; text-align: center; margin-top: 15%;">
+  <h1>503 Service Unavailable</h1>
+  <p>The service is temporarily unavailable. Please try again shortly.</p>
+</body>
+</html>

--- a/src/test/java/org/sensepitch/edge/CompleteTest.java
+++ b/src/test/java/org/sensepitch/edge/CompleteTest.java
@@ -213,6 +213,12 @@ class CompleteTest {
     }
 
     @Step
+    Steps then_the_response_header_is(CharSequence name, String value) {
+      assertThat(response.headers().get(name)).isEqualTo(value);
+      return this;
+    }
+
+    @Step
     Steps then_channel_closed() {
       assertThat(ingressChannel.isActive()).isFalse();
       return this;

--- a/src/test/java/org/sensepitch/edge/CookieGateTest.java
+++ b/src/test/java/org/sensepitch/edge/CookieGateTest.java
@@ -20,9 +20,9 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
-import io.netty.handler.codec.http.cookie.ClientCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -55,8 +55,7 @@ public class CookieGateTest {
             FullHttpResponse.class,
             response -> {
               assertThat(response.status().code()).isEqualTo(200);
-              assertThat(response.headers().get(HttpHeaderNames.SET_COOKIE))
-                  .isNotBlank();
+              assertThat(response.headers().get(HttpHeaderNames.SET_COOKIE)).isNotBlank();
               String payload =
                   ByteBufUtil.getBytes(response.content()).length == 0
                       ? ""
@@ -125,8 +124,7 @@ public class CookieGateTest {
     init(List.of(CookieGateConfig.builder().name(COOKIE_NAME).build()));
     DefaultHttpRequest req =
         new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/private");
-    String cookieHeader =
-        ServerCookieEncoder.STRICT.encode(new DefaultCookie(COOKIE_NAME, "1"));
+    String cookieHeader = ServerCookieEncoder.STRICT.encode(new DefaultCookie(COOKIE_NAME, "1"));
     req.headers().set(HttpHeaderNames.COOKIE, cookieHeader);
     request(req);
     assertThat(passed).isTrue();

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -1,0 +1,181 @@
+package org.sensepitch.edge;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link FallbackHandler} against the streamed response shape a real upstream produces:
+ * an {@link HttpResponse} head, then {@link HttpContent} chunks, then a {@link LastHttpContent},
+ * as opposed to the single {@link FullHttpResponse} covered in {@link FallbackTest}.
+ *
+ * @author Raid Thabet
+ */
+public class FallbackStreamingTest {
+
+  private static final FallbackConfig CONFIG =
+      FallbackConfig.builder()
+          .unavailableText("global-unavailable") // 18 bytes
+          .errorText("global-error") // 12 bytes
+          .build();
+
+  private EmbeddedChannel channel;
+  private final List<Object> written = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    ChannelOutboundHandler capture =
+        new ChannelOutboundHandlerAdapter() {
+          @Override
+          public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            written.add(msg);
+            ctx.write(msg, promise);
+          }
+        };
+    channel = new EmbeddedChannel(capture, new FallbackHandler(CONFIG));
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.finishAndReleaseAll();
+  }
+
+  /** The first response object the handler wrote downstream (head or aggregated fallback). */
+  private HttpResponse response() {
+    for (Object o : written) {
+      if (o instanceof HttpResponse r) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  /** The concatenated body of everything the handler wrote downstream. */
+  private String body() {
+    StringBuilder sb = new StringBuilder();
+    for (Object o : written) {
+      if (o instanceof HttpContent c) {
+        sb.append(c.content().toString(StandardCharsets.UTF_8));
+      }
+    }
+    return sb.toString();
+  }
+
+  private static DefaultHttpContent chunk(String text) {
+    return new DefaultHttpContent(Unpooled.copiedBuffer(text, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testUnavailableUsesFallback() {
+    DefaultHttpContent originChunk = chunk("origin-body"); // kept to assert it is released
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+        originChunk,
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(body()).isEqualTo("global-unavailable");
+    assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+    assertThat(originChunk.refCnt()).isZero(); // origin body dropped and released by the handler
+  }
+
+  @Test
+  public void testErrorUsesFallback() {
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR),
+        chunk("origin-body"),
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(body()).isEqualTo("global-error");
+    assertThat(response().status()).isEqualTo(INTERNAL_SERVER_ERROR);
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
+  }
+
+  @Test
+  public void testMultiChunkBodyFullySwallowed() {
+    DefaultHttpContent c1 = chunk("chunk-1");
+    DefaultHttpContent c2 = chunk("chunk-2");
+    DefaultLastHttpContent last =
+        new DefaultLastHttpContent(Unpooled.copiedBuffer("chunk-3", StandardCharsets.UTF_8));
+
+    channel.writeOutbound(new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), c1, c2, last);
+
+    // only the fallback body is emitted, exactly once; none of the origin chunks leak through
+    assertThat(body()).isEqualTo("global-unavailable");
+    assertThat(c1.refCnt()).isZero();
+    assertThat(c2.refCnt()).isZero();
+    assertThat(last.refCnt()).isZero();
+  }
+
+  @Test
+  public void testNon5xxPassesThrough() {
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-body"), LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(response().status()).isEqualTo(OK);
+    assertThat(body()).isEqualTo("real-body"); // forwarded unchanged, fallback NOT applied
+  }
+
+  @Test
+  public void testHeadThenEmptyLastUsesFallback() {
+    // 5xx head with no separate content chunk, terminated straight away
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(body()).isEqualTo("global-unavailable");
+    assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void testPreservesConnectionCloseHeader() {
+    DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
+    head.headers().set(HttpHeaderNames.CONNECTION, "close");
+
+    channel.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(response().headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
+  }
+
+  @Test
+  public void testKeepAliveResetsFlagBetweenResponses() {
+    // response 1 on the connection: streamed 503 -> replaced with the fallback
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+        chunk("origin-1"),
+        LastHttpContent.EMPTY_LAST_CONTENT);
+    assertThat(body()).isEqualTo("global-unavailable");
+
+    // response 2 on the SAME connection: streamed 200 -> must pass through untouched.
+    // If the suppression flag were not reset per head, this body would be swallowed.
+    written.clear();
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-2"), LastHttpContent.EMPTY_LAST_CONTENT);
+    assertThat(response().status()).isEqualTo(OK);
+    assertThat(body()).isEqualTo("real-2");
+  }
+}

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -59,7 +59,7 @@ public class FallbackStreamingTest {
 
   @BeforeEach
   void setUp() {
-    channel = new EmbeddedChannel(capture(written), new FallbackHandler(CONFIG));
+    channel = new EmbeddedChannel(capture(written), new Fallback(CONFIG).newHandler());
   }
 
   @AfterEach
@@ -130,7 +130,7 @@ public class FallbackStreamingTest {
             .errorResponse(ResponseConfig.builder().text("err").build())
             .build();
     List<Object> out = new ArrayList<>();
-    EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(cfg));
+    EmbeddedChannel ch = new EmbeddedChannel(capture(out), new Fallback(cfg).newHandler());
 
     ch.writeOutbound(
         new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
@@ -239,7 +239,7 @@ public class FallbackStreamingTest {
             .errorResponse(ResponseConfig.builder().text("err").build())
             .build();
     List<Object> out = new ArrayList<>();
-    EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(redirectCfg));
+    EmbeddedChannel ch = new EmbeddedChannel(capture(out), new Fallback(redirectCfg).newHandler());
 
     DefaultHttpContent originChunk = chunk("origin-body");
     ch.writeOutbound(
@@ -273,7 +273,7 @@ public class FallbackStreamingTest {
     List<Object> out = new ArrayList<>();
     EmbeddedChannel ch =
         new EmbeddedChannel(
-            capture(out), new FallbackHandler(FallbackConfig.DEFAULTS.merge(redirectCfg)));
+            capture(out), new Fallback(FallbackConfig.DEFAULTS.merge(redirectCfg)).newHandler());
 
     DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
     head.headers().set(HttpHeaderNames.CONNECTION, "close");

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -235,7 +235,7 @@ public class FallbackStreamingTest {
     FallbackConfig redirectCfg =
         FallbackConfig.builder()
             .unavailableResponse(
-                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
+                ResponseConfig.builder().location("https://status.example/").status(307).build())
             .errorResponse(ResponseConfig.builder().text("err").build())
             .build();
     List<Object> out = new ArrayList<>();
@@ -268,7 +268,7 @@ public class FallbackStreamingTest {
     FallbackConfig redirectCfg =
         FallbackConfig.builder()
             .unavailableResponse(
-                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
+                ResponseConfig.builder().location("https://status.example/").status(307).build())
             .build();
     List<Object> out = new ArrayList<>();
     EmbeddedChannel ch =

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -256,4 +256,34 @@ public class FallbackStreamingTest {
 
         ch.finishAndReleaseAll();
     }
+    
+    @Test
+    public void testStreamedRedirectPreservesConnectionCloseHeader() {
+        FallbackConfig redirectCfg =
+                FallbackConfig.builder()
+                        .unavailableResponse(
+                                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
+                        .build();
+        List<Object> out = new ArrayList<>();
+        EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(FallbackConfig.DEFAULTS.merge(redirectCfg)));
+
+        DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
+        head.headers().set(HttpHeaderNames.CONNECTION, "close");
+        ch.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
+
+        HttpResponse response = null;
+        for (Object o : out) {
+            if (o instanceof HttpResponse r) {
+                response = r;
+                break;
+            }
+        }
+        
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isEqualTo(TEMPORARY_REDIRECT);
+        assertThat(response.headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
+
+        ch.finishAndReleaseAll();
+    }
+    
 }

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -121,6 +121,43 @@ public class FallbackStreamingTest {
     }
 
     @Test
+    public void testPageHonorsExplicitStatus() {
+        FallbackConfig cfg =
+                FallbackConfig.builder()
+                        .unavailableResponse(
+                                ResponseConfig.builder().text("down page").status(200).build())
+                        .errorResponse(ResponseConfig.builder().text("err").build())
+                        .build();
+        List<Object> out = new ArrayList<>();
+        EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(cfg));
+
+        ch.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+                chunk("origin-body"),
+                LastHttpContent.EMPTY_LAST_CONTENT);
+
+        HttpResponse head = null;
+        for (Object o : out) {
+            if (o instanceof HttpResponse r) {
+                head = r;
+                break;
+            }
+        }
+        assertThat(head).isNotNull();
+        assertThat(head.status()).isEqualTo(OK);
+
+        StringBuilder sb = new StringBuilder();
+        for (Object o : out) {
+            if (o instanceof HttpContent c) {
+                sb.append(c.content().toString(StandardCharsets.UTF_8));
+            }
+        }
+        assertThat(sb.toString()).isEqualTo("down page");
+
+        ch.finishAndReleaseAll();
+    }
+
+    @Test
     public void testMultiChunkBodyFullySwallowed() {
         DefaultHttpContent c1 = chunk("chunk-1");
         DefaultHttpContent c2 = chunk("chunk-2");

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -7,7 +7,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
@@ -29,261 +28,269 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests {@link FallbackHandler} against the streamed response shape a real upstream produces:
- * an {@link HttpResponse} head, then {@link HttpContent} chunks, then a {@link LastHttpContent},
- * as opposed to the single {@link io.netty.handler.codec.http.FullHttpResponse} covered in
- * {@link FallbackTest}.
+ * Tests {@link FallbackHandler} against the streamed response shape a real upstream produces: an
+ * {@link HttpResponse} head, then {@link HttpContent} chunks, then a {@link LastHttpContent}, as
+ * opposed to the single {@link io.netty.handler.codec.http.FullHttpResponse} covered in {@link
+ * FallbackTest}.
  *
  * @author Raid Thabet
  */
 public class FallbackStreamingTest {
 
-    private static final FallbackConfig CONFIG =
-            FallbackConfig.builder()
-                    .unavailableResponse(ResponseConfig.builder().text("global-unavailable").build()) // 18 bytes
-                    .errorResponse(ResponseConfig.builder().text("global-error").build()) // 12 bytes
-                    .build();
+  private static final FallbackConfig CONFIG =
+      FallbackConfig.builder()
+          .unavailableResponse(
+              ResponseConfig.builder().text("global-unavailable").build()) // 18 bytes
+          .errorResponse(ResponseConfig.builder().text("global-error").build()) // 12 bytes
+          .build();
 
-    private EmbeddedChannel channel;
-    private final List<Object> written = new ArrayList<>();
+  private EmbeddedChannel channel;
+  private final List<Object> written = new ArrayList<>();
 
-    private static ChannelOutboundHandler capture(List<Object> sink) {
-        return new ChannelOutboundHandlerAdapter() {
-            @Override
-            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                sink.add(msg);
-                ctx.write(msg, promise);
-            }
-        };
+  private static ChannelOutboundHandler capture(List<Object> sink) {
+    return new ChannelOutboundHandlerAdapter() {
+      @Override
+      public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+        sink.add(msg);
+        ctx.write(msg, promise);
+      }
+    };
+  }
+
+  @BeforeEach
+  void setUp() {
+    channel = new EmbeddedChannel(capture(written), new FallbackHandler(CONFIG));
+  }
+
+  @AfterEach
+  void tearDown() {
+    channel.finishAndReleaseAll();
+  }
+
+  private HttpResponse response() {
+    for (Object o : written) {
+      if (o instanceof HttpResponse r) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  private String body() {
+    StringBuilder sb = new StringBuilder();
+    for (Object o : written) {
+      if (o instanceof HttpContent c) {
+        sb.append(c.content().toString(StandardCharsets.UTF_8));
+      }
+    }
+    return sb.toString();
+  }
+
+  private static DefaultHttpContent chunk(String text) {
+    return new DefaultHttpContent(Unpooled.copiedBuffer(text, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testUnavailableUsesFallback() {
+    DefaultHttpContent originChunk = chunk("origin-body"); // kept to assert it is released
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+        originChunk,
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(body()).isEqualTo("global-unavailable");
+    assertThat(response()).isNotNull();
+    assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE))
+        .isEqualTo("text/html; charset=UTF-8");
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+    assertThat(originChunk.refCnt()).isZero(); // origin body dropped and released by the handler
+  }
+
+  @Test
+  public void testErrorUsesFallback() {
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR),
+        chunk("origin-body"),
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(body()).isEqualTo("global-error");
+    assertThat(response()).isNotNull();
+    assertThat(response().status()).isEqualTo(INTERNAL_SERVER_ERROR);
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE))
+        .isEqualTo("text/html; charset=UTF-8");
+    assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
+  }
+
+  @Test
+  public void testPageHonorsExplicitStatus() {
+    FallbackConfig cfg =
+        FallbackConfig.builder()
+            .unavailableResponse(ResponseConfig.builder().text("down page").status(200).build())
+            .errorResponse(ResponseConfig.builder().text("err").build())
+            .build();
+    List<Object> out = new ArrayList<>();
+    EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(cfg));
+
+    ch.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+        chunk("origin-body"),
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    HttpResponse head = null;
+    for (Object o : out) {
+      if (o instanceof HttpResponse r) {
+        head = r;
+        break;
+      }
+    }
+    assertThat(head).isNotNull();
+    assertThat(head.status()).isEqualTo(OK);
+
+    StringBuilder sb = new StringBuilder();
+    for (Object o : out) {
+      if (o instanceof HttpContent c) {
+        sb.append(c.content().toString(StandardCharsets.UTF_8));
+      }
+    }
+    assertThat(sb.toString()).isEqualTo("down page");
+
+    ch.finishAndReleaseAll();
+  }
+
+  @Test
+  public void testMultiChunkBodyFullySwallowed() {
+    DefaultHttpContent c1 = chunk("chunk-1");
+    DefaultHttpContent c2 = chunk("chunk-2");
+    DefaultLastHttpContent last =
+        new DefaultLastHttpContent(Unpooled.copiedBuffer("chunk-3", StandardCharsets.UTF_8));
+
+    channel.writeOutbound(new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), c1, c2, last);
+
+    // only the fallback body is emitted, exactly once; none of the origin chunks leak through
+    assertThat(body()).isEqualTo("global-unavailable");
+    assertThat(c1.refCnt()).isZero();
+    assertThat(c2.refCnt()).isZero();
+    assertThat(last.refCnt()).isZero();
+  }
+
+  @Test
+  public void testNon5xxPassesThrough() {
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, OK),
+        chunk("real-body"),
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(response()).isNotNull();
+    assertThat(response().status()).isEqualTo(OK);
+    assertThat(body()).isEqualTo("real-body"); // forwarded unchanged, fallback NOT applied
+  }
+
+  @Test
+  public void testHeadThenEmptyLastUsesFallback() {
+    // 5xx head with no separate content chunk, terminated straight away
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(body()).isEqualTo("global-unavailable");
+    assertThat(response()).isNotNull();
+    assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  public void testPreservesConnectionCloseHeader() {
+    DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
+    head.headers().set(HttpHeaderNames.CONNECTION, "close");
+
+    channel.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
+
+    assertThat(response()).isNotNull();
+    assertThat(response().headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
+  }
+
+  @Test
+  public void testKeepAliveResetsFlagBetweenResponses() {
+    // response 1 on the connection: streamed 503 -> replaced with the fallback
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+        chunk("origin-1"),
+        LastHttpContent.EMPTY_LAST_CONTENT);
+    assertThat(body()).isEqualTo("global-unavailable");
+
+    // response 2 on the SAME connection: streamed 200 -> must pass through untouched.
+    written.clear();
+    channel.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-2"), LastHttpContent.EMPTY_LAST_CONTENT);
+    assertThat(response()).isNotNull();
+    assertThat(response().status()).isEqualTo(OK);
+    assertThat(body()).isEqualTo("real-2");
+  }
+
+  /**
+   * A streamed 5xx whose slot is a redirect: the head becomes a 3xx and the origin body is
+   * swallowed.
+   */
+  @Test
+  public void testStreamedRedirectSwallowsBody() {
+    FallbackConfig redirectCfg =
+        FallbackConfig.builder()
+            .unavailableResponse(
+                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
+            .errorResponse(ResponseConfig.builder().text("err").build())
+            .build();
+    List<Object> out = new ArrayList<>();
+    EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(redirectCfg));
+
+    DefaultHttpContent originChunk = chunk("origin-body");
+    ch.writeOutbound(
+        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+        originChunk,
+        LastHttpContent.EMPTY_LAST_CONTENT);
+
+    HttpResponse head = null;
+    for (Object o : out) {
+      if (o instanceof HttpResponse r) {
+        head = r;
+        break;
+      }
+    }
+    assertThat(head).isNotNull();
+    assertThat(head.status()).isEqualTo(TEMPORARY_REDIRECT);
+    assertThat(head.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("https://status.example/");
+    assertThat(head.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
+    assertThat(originChunk.refCnt()).isZero(); // origin body dropped despite the redirect swap
+
+    ch.finishAndReleaseAll();
+  }
+
+  @Test
+  public void testStreamedRedirectPreservesConnectionCloseHeader() {
+    FallbackConfig redirectCfg =
+        FallbackConfig.builder()
+            .unavailableResponse(
+                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
+            .build();
+    List<Object> out = new ArrayList<>();
+    EmbeddedChannel ch =
+        new EmbeddedChannel(
+            capture(out), new FallbackHandler(FallbackConfig.DEFAULTS.merge(redirectCfg)));
+
+    DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
+    head.headers().set(HttpHeaderNames.CONNECTION, "close");
+    ch.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
+
+    HttpResponse response = null;
+    for (Object o : out) {
+      if (o instanceof HttpResponse r) {
+        response = r;
+        break;
+      }
     }
 
-    @BeforeEach
-    void setUp() {
-        channel = new EmbeddedChannel(capture(written), new FallbackHandler(CONFIG));
-    }
+    assertThat(response).isNotNull();
+    assertThat(response.status()).isEqualTo(TEMPORARY_REDIRECT);
+    assertThat(response.headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
 
-    @AfterEach
-    void tearDown() {
-        channel.finishAndReleaseAll();
-    }
-
-    private HttpResponse response() {
-        for (Object o : written) {
-            if (o instanceof HttpResponse r) {
-                return r;
-            }
-        }
-        return null;
-    }
-
-    private String body() {
-        StringBuilder sb = new StringBuilder();
-        for (Object o : written) {
-            if (o instanceof HttpContent c) {
-                sb.append(c.content().toString(StandardCharsets.UTF_8));
-            }
-        }
-        return sb.toString();
-    }
-
-    private static DefaultHttpContent chunk(String text) {
-        return new DefaultHttpContent(Unpooled.copiedBuffer(text, StandardCharsets.UTF_8));
-    }
-
-    @Test
-    public void testUnavailableUsesFallback() {
-        DefaultHttpContent originChunk = chunk("origin-body"); // kept to assert it is released
-        channel.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
-                originChunk,
-                LastHttpContent.EMPTY_LAST_CONTENT);
-
-        assertThat(body()).isEqualTo("global-unavailable");
-        assertThat(response()).isNotNull();
-        assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
-        assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
-        assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
-        assertThat(originChunk.refCnt()).isZero(); // origin body dropped and released by the handler
-    }
-
-    @Test
-    public void testErrorUsesFallback() {
-        channel.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR),
-                chunk("origin-body"),
-                LastHttpContent.EMPTY_LAST_CONTENT);
-
-        assertThat(body()).isEqualTo("global-error");
-        assertThat(response()).isNotNull();
-        assertThat(response().status()).isEqualTo(INTERNAL_SERVER_ERROR);
-        assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
-        assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
-    }
-
-    @Test
-    public void testPageHonorsExplicitStatus() {
-        FallbackConfig cfg =
-                FallbackConfig.builder()
-                        .unavailableResponse(
-                                ResponseConfig.builder().text("down page").status(200).build())
-                        .errorResponse(ResponseConfig.builder().text("err").build())
-                        .build();
-        List<Object> out = new ArrayList<>();
-        EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(cfg));
-
-        ch.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
-                chunk("origin-body"),
-                LastHttpContent.EMPTY_LAST_CONTENT);
-
-        HttpResponse head = null;
-        for (Object o : out) {
-            if (o instanceof HttpResponse r) {
-                head = r;
-                break;
-            }
-        }
-        assertThat(head).isNotNull();
-        assertThat(head.status()).isEqualTo(OK);
-
-        StringBuilder sb = new StringBuilder();
-        for (Object o : out) {
-            if (o instanceof HttpContent c) {
-                sb.append(c.content().toString(StandardCharsets.UTF_8));
-            }
-        }
-        assertThat(sb.toString()).isEqualTo("down page");
-
-        ch.finishAndReleaseAll();
-    }
-
-    @Test
-    public void testMultiChunkBodyFullySwallowed() {
-        DefaultHttpContent c1 = chunk("chunk-1");
-        DefaultHttpContent c2 = chunk("chunk-2");
-        DefaultLastHttpContent last =
-                new DefaultLastHttpContent(Unpooled.copiedBuffer("chunk-3", StandardCharsets.UTF_8));
-
-        channel.writeOutbound(new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), c1, c2, last);
-
-        // only the fallback body is emitted, exactly once; none of the origin chunks leak through
-        assertThat(body()).isEqualTo("global-unavailable");
-        assertThat(c1.refCnt()).isZero();
-        assertThat(c2.refCnt()).isZero();
-        assertThat(last.refCnt()).isZero();
-    }
-
-    @Test
-    public void testNon5xxPassesThrough() {
-        channel.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-body"), LastHttpContent.EMPTY_LAST_CONTENT);
-
-        assertThat(response()).isNotNull();
-        assertThat(response().status()).isEqualTo(OK);
-        assertThat(body()).isEqualTo("real-body"); // forwarded unchanged, fallback NOT applied
-    }
-
-    @Test
-    public void testHeadThenEmptyLastUsesFallback() {
-        // 5xx head with no separate content chunk, terminated straight away
-        channel.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), LastHttpContent.EMPTY_LAST_CONTENT);
-
-        assertThat(body()).isEqualTo("global-unavailable");
-        assertThat(response()).isNotNull();
-        assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
-    }
-
-    @Test
-    public void testPreservesConnectionCloseHeader() {
-        DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
-        head.headers().set(HttpHeaderNames.CONNECTION, "close");
-
-        channel.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
-
-        assertThat(response()).isNotNull();
-        assertThat(response().headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
-    }
-
-    @Test
-    public void testKeepAliveResetsFlagBetweenResponses() {
-        // response 1 on the connection: streamed 503 -> replaced with the fallback
-        channel.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
-                chunk("origin-1"),
-                LastHttpContent.EMPTY_LAST_CONTENT);
-        assertThat(body()).isEqualTo("global-unavailable");
-
-        // response 2 on the SAME connection: streamed 200 -> must pass through untouched.
-        written.clear();
-        channel.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-2"), LastHttpContent.EMPTY_LAST_CONTENT);
-        assertThat(response()).isNotNull();
-        assertThat(response().status()).isEqualTo(OK);
-        assertThat(body()).isEqualTo("real-2");
-    }
-
-    /** A streamed 5xx whose slot is a redirect: the head becomes a 3xx and the origin body is swallowed. */
-    @Test
-    public void testStreamedRedirectSwallowsBody() {
-        FallbackConfig redirectCfg =
-                FallbackConfig.builder()
-                        .unavailableResponse(
-                                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
-                        .errorResponse(ResponseConfig.builder().text("err").build())
-                        .build();
-        List<Object> out = new ArrayList<>();
-        EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(redirectCfg));
-
-        DefaultHttpContent originChunk = chunk("origin-body");
-        ch.writeOutbound(
-                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
-                originChunk,
-                LastHttpContent.EMPTY_LAST_CONTENT);
-
-        HttpResponse head = null;
-        for (Object o : out) {
-            if (o instanceof HttpResponse r) {
-                head = r;
-                break;
-            }
-        }
-        assertThat(head).isNotNull();
-        assertThat(head.status()).isEqualTo(TEMPORARY_REDIRECT);
-        assertThat(head.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("https://status.example/");
-        assertThat(head.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
-        assertThat(originChunk.refCnt()).isZero(); // origin body dropped despite the redirect swap
-
-        ch.finishAndReleaseAll();
-    }
-    
-    @Test
-    public void testStreamedRedirectPreservesConnectionCloseHeader() {
-        FallbackConfig redirectCfg =
-                FallbackConfig.builder()
-                        .unavailableResponse(
-                                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
-                        .build();
-        List<Object> out = new ArrayList<>();
-        EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(FallbackConfig.DEFAULTS.merge(redirectCfg)));
-
-        DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
-        head.headers().set(HttpHeaderNames.CONNECTION, "close");
-        ch.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
-
-        HttpResponse response = null;
-        for (Object o : out) {
-            if (o instanceof HttpResponse r) {
-                response = r;
-                break;
-            }
-        }
-        
-        assertThat(response).isNotNull();
-        assertThat(response.status()).isEqualTo(TEMPORARY_REDIRECT);
-        assertThat(response.headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
-
-        ch.finishAndReleaseAll();
-    }
-    
+    ch.finishAndReleaseAll();
+  }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackStreamingTest.java
@@ -3,8 +3,10 @@ package org.sensepitch.edge;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -15,7 +17,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponse;
@@ -30,152 +31,192 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests {@link FallbackHandler} against the streamed response shape a real upstream produces:
  * an {@link HttpResponse} head, then {@link HttpContent} chunks, then a {@link LastHttpContent},
- * as opposed to the single {@link FullHttpResponse} covered in {@link FallbackTest}.
+ * as opposed to the single {@link io.netty.handler.codec.http.FullHttpResponse} covered in
+ * {@link FallbackTest}.
  *
  * @author Raid Thabet
  */
 public class FallbackStreamingTest {
 
-  private static final FallbackConfig CONFIG =
-      FallbackConfig.builder()
-          .unavailableText("global-unavailable") // 18 bytes
-          .errorText("global-error") // 12 bytes
-          .build();
+    private static final FallbackConfig CONFIG =
+            FallbackConfig.builder()
+                    .unavailableResponse(ResponseConfig.builder().text("global-unavailable").build()) // 18 bytes
+                    .errorResponse(ResponseConfig.builder().text("global-error").build()) // 12 bytes
+                    .build();
 
-  private EmbeddedChannel channel;
-  private final List<Object> written = new ArrayList<>();
+    private EmbeddedChannel channel;
+    private final List<Object> written = new ArrayList<>();
 
-  @BeforeEach
-  void setUp() {
-    ChannelOutboundHandler capture =
-        new ChannelOutboundHandlerAdapter() {
-          @Override
-          public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-            written.add(msg);
-            ctx.write(msg, promise);
-          }
+    private static ChannelOutboundHandler capture(List<Object> sink) {
+        return new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                sink.add(msg);
+                ctx.write(msg, promise);
+            }
         };
-    channel = new EmbeddedChannel(capture, new FallbackHandler(CONFIG));
-  }
-
-  @AfterEach
-  void tearDown() {
-    channel.finishAndReleaseAll();
-  }
-
-  /** The first response object the handler wrote downstream (head or aggregated fallback). */
-  private HttpResponse response() {
-    for (Object o : written) {
-      if (o instanceof HttpResponse r) {
-        return r;
-      }
     }
-    return null;
-  }
 
-  /** The concatenated body of everything the handler wrote downstream. */
-  private String body() {
-    StringBuilder sb = new StringBuilder();
-    for (Object o : written) {
-      if (o instanceof HttpContent c) {
-        sb.append(c.content().toString(StandardCharsets.UTF_8));
-      }
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel(capture(written), new FallbackHandler(CONFIG));
     }
-    return sb.toString();
-  }
 
-  private static DefaultHttpContent chunk(String text) {
-    return new DefaultHttpContent(Unpooled.copiedBuffer(text, StandardCharsets.UTF_8));
-  }
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
+    }
 
-  @Test
-  public void testUnavailableUsesFallback() {
-    DefaultHttpContent originChunk = chunk("origin-body"); // kept to assert it is released
-    channel.writeOutbound(
-        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
-        originChunk,
-        LastHttpContent.EMPTY_LAST_CONTENT);
+    private HttpResponse response() {
+        for (Object o : written) {
+            if (o instanceof HttpResponse r) {
+                return r;
+            }
+        }
+        return null;
+    }
 
-    assertThat(body()).isEqualTo("global-unavailable");
-    assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
-    assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
-    assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
-    assertThat(originChunk.refCnt()).isZero(); // origin body dropped and released by the handler
-  }
+    private String body() {
+        StringBuilder sb = new StringBuilder();
+        for (Object o : written) {
+            if (o instanceof HttpContent c) {
+                sb.append(c.content().toString(StandardCharsets.UTF_8));
+            }
+        }
+        return sb.toString();
+    }
 
-  @Test
-  public void testErrorUsesFallback() {
-    channel.writeOutbound(
-        new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR),
-        chunk("origin-body"),
-        LastHttpContent.EMPTY_LAST_CONTENT);
+    private static DefaultHttpContent chunk(String text) {
+        return new DefaultHttpContent(Unpooled.copiedBuffer(text, StandardCharsets.UTF_8));
+    }
 
-    assertThat(body()).isEqualTo("global-error");
-    assertThat(response().status()).isEqualTo(INTERNAL_SERVER_ERROR);
-    assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
-    assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
-  }
+    @Test
+    public void testUnavailableUsesFallback() {
+        DefaultHttpContent originChunk = chunk("origin-body"); // kept to assert it is released
+        channel.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+                originChunk,
+                LastHttpContent.EMPTY_LAST_CONTENT);
 
-  @Test
-  public void testMultiChunkBodyFullySwallowed() {
-    DefaultHttpContent c1 = chunk("chunk-1");
-    DefaultHttpContent c2 = chunk("chunk-2");
-    DefaultLastHttpContent last =
-        new DefaultLastHttpContent(Unpooled.copiedBuffer("chunk-3", StandardCharsets.UTF_8));
+        assertThat(body()).isEqualTo("global-unavailable");
+        assertThat(response()).isNotNull();
+        assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
+        assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
+        assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+        assertThat(originChunk.refCnt()).isZero(); // origin body dropped and released by the handler
+    }
 
-    channel.writeOutbound(new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), c1, c2, last);
+    @Test
+    public void testErrorUsesFallback() {
+        channel.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR),
+                chunk("origin-body"),
+                LastHttpContent.EMPTY_LAST_CONTENT);
 
-    // only the fallback body is emitted, exactly once; none of the origin chunks leak through
-    assertThat(body()).isEqualTo("global-unavailable");
-    assertThat(c1.refCnt()).isZero();
-    assertThat(c2.refCnt()).isZero();
-    assertThat(last.refCnt()).isZero();
-  }
+        assertThat(body()).isEqualTo("global-error");
+        assertThat(response()).isNotNull();
+        assertThat(response().status()).isEqualTo(INTERNAL_SERVER_ERROR);
+        assertThat(response().headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html; charset=UTF-8");
+        assertThat(response().headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
+    }
 
-  @Test
-  public void testNon5xxPassesThrough() {
-    channel.writeOutbound(
-        new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-body"), LastHttpContent.EMPTY_LAST_CONTENT);
+    @Test
+    public void testMultiChunkBodyFullySwallowed() {
+        DefaultHttpContent c1 = chunk("chunk-1");
+        DefaultHttpContent c2 = chunk("chunk-2");
+        DefaultLastHttpContent last =
+                new DefaultLastHttpContent(Unpooled.copiedBuffer("chunk-3", StandardCharsets.UTF_8));
 
-    assertThat(response().status()).isEqualTo(OK);
-    assertThat(body()).isEqualTo("real-body"); // forwarded unchanged, fallback NOT applied
-  }
+        channel.writeOutbound(new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), c1, c2, last);
 
-  @Test
-  public void testHeadThenEmptyLastUsesFallback() {
-    // 5xx head with no separate content chunk, terminated straight away
-    channel.writeOutbound(
-        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), LastHttpContent.EMPTY_LAST_CONTENT);
+        // only the fallback body is emitted, exactly once; none of the origin chunks leak through
+        assertThat(body()).isEqualTo("global-unavailable");
+        assertThat(c1.refCnt()).isZero();
+        assertThat(c2.refCnt()).isZero();
+        assertThat(last.refCnt()).isZero();
+    }
 
-    assertThat(body()).isEqualTo("global-unavailable");
-    assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
-  }
+    @Test
+    public void testNon5xxPassesThrough() {
+        channel.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-body"), LastHttpContent.EMPTY_LAST_CONTENT);
 
-  @Test
-  public void testPreservesConnectionCloseHeader() {
-    DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
-    head.headers().set(HttpHeaderNames.CONNECTION, "close");
+        assertThat(response()).isNotNull();
+        assertThat(response().status()).isEqualTo(OK);
+        assertThat(body()).isEqualTo("real-body"); // forwarded unchanged, fallback NOT applied
+    }
 
-    channel.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
+    @Test
+    public void testHeadThenEmptyLastUsesFallback() {
+        // 5xx head with no separate content chunk, terminated straight away
+        channel.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE), LastHttpContent.EMPTY_LAST_CONTENT);
 
-    assertThat(response().headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
-  }
+        assertThat(body()).isEqualTo("global-unavailable");
+        assertThat(response()).isNotNull();
+        assertThat(response().status()).isEqualTo(SERVICE_UNAVAILABLE);
+    }
 
-  @Test
-  public void testKeepAliveResetsFlagBetweenResponses() {
-    // response 1 on the connection: streamed 503 -> replaced with the fallback
-    channel.writeOutbound(
-        new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
-        chunk("origin-1"),
-        LastHttpContent.EMPTY_LAST_CONTENT);
-    assertThat(body()).isEqualTo("global-unavailable");
+    @Test
+    public void testPreservesConnectionCloseHeader() {
+        DefaultHttpResponse head = new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE);
+        head.headers().set(HttpHeaderNames.CONNECTION, "close");
 
-    // response 2 on the SAME connection: streamed 200 -> must pass through untouched.
-    // If the suppression flag were not reset per head, this body would be swallowed.
-    written.clear();
-    channel.writeOutbound(
-        new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-2"), LastHttpContent.EMPTY_LAST_CONTENT);
-    assertThat(response().status()).isEqualTo(OK);
-    assertThat(body()).isEqualTo("real-2");
-  }
+        channel.writeOutbound(head, LastHttpContent.EMPTY_LAST_CONTENT);
+
+        assertThat(response()).isNotNull();
+        assertThat(response().headers().get(HttpHeaderNames.CONNECTION)).isEqualTo("close");
+    }
+
+    @Test
+    public void testKeepAliveResetsFlagBetweenResponses() {
+        // response 1 on the connection: streamed 503 -> replaced with the fallback
+        channel.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+                chunk("origin-1"),
+                LastHttpContent.EMPTY_LAST_CONTENT);
+        assertThat(body()).isEqualTo("global-unavailable");
+
+        // response 2 on the SAME connection: streamed 200 -> must pass through untouched.
+        written.clear();
+        channel.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, OK), chunk("real-2"), LastHttpContent.EMPTY_LAST_CONTENT);
+        assertThat(response()).isNotNull();
+        assertThat(response().status()).isEqualTo(OK);
+        assertThat(body()).isEqualTo("real-2");
+    }
+
+    /** A streamed 5xx whose slot is a redirect: the head becomes a 3xx and the origin body is swallowed. */
+    @Test
+    public void testStreamedRedirectSwallowsBody() {
+        FallbackConfig redirectCfg =
+                FallbackConfig.builder()
+                        .unavailableResponse(
+                                ResponseConfig.builder().temporaryRedirect("https://status.example/").build())
+                        .errorResponse(ResponseConfig.builder().text("err").build())
+                        .build();
+        List<Object> out = new ArrayList<>();
+        EmbeddedChannel ch = new EmbeddedChannel(capture(out), new FallbackHandler(redirectCfg));
+
+        DefaultHttpContent originChunk = chunk("origin-body");
+        ch.writeOutbound(
+                new DefaultHttpResponse(HTTP_1_1, SERVICE_UNAVAILABLE),
+                originChunk,
+                LastHttpContent.EMPTY_LAST_CONTENT);
+
+        HttpResponse head = null;
+        for (Object o : out) {
+            if (o instanceof HttpResponse r) {
+                head = r;
+                break;
+            }
+        }
+        assertThat(head).isNotNull();
+        assertThat(head.status()).isEqualTo(TEMPORARY_REDIRECT);
+        assertThat(head.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("https://status.example/");
+        assertThat(head.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
+        assertThat(originChunk.refCnt()).isZero(); // origin body dropped despite the redirect swap
+
+        ch.finishAndReleaseAll();
+    }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -1,11 +1,16 @@
 package org.sensepitch.edge;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import net.serenitybdd.junit5.SerenityJUnit5Extension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -54,51 +59,59 @@ public class FallbackTest {
                                     Map.entry(
                                             "ok.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(200).text("real-body").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build()).build()),
+                                                    .response(ResponseConfig.builder().status(200).text("real-body").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build()).build()),
                                     Map.entry(
                                             "notfound.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(404).text("real-404").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build()).build()),
+                                                    .response(ResponseConfig.builder().status(404).text("real-404").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build()).build()),
                                     Map.entry(
                                             "unavailable-page.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build())
-                                            .fallback(FallbackConfig.builder().unavailablePage("fallback/unavailable_page.html").build())
-                                            .build()),
+                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().unavailablePage("fallback/unavailable_page.html").build())
+                                                    .build()),
+                                    Map.entry(
+                                            "non-existent-page.com",
+                                            SiteConfig.builder()
+                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().unavailablePage("fallback/non_existent_page.html").build())
+                                                    .build()
+                                    ),
                                     Map.entry(
                                             "error-page.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build())
-                                            .fallback(FallbackConfig.builder().errorPage("fallback/error_page.html").build())
-                                            .build()),
+                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().errorPage("fallback/error_page.html").build())
+                                                    .build()),
                                     Map.entry(
                                             "unavailable-text.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build())
-                                            .fallback(FallbackConfig.builder().unavailableText("service is unavailable").build())
-                                            .build()),
+                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().unavailableText("service is unavailable").build())
+                                                    .build()),
                                     Map.entry(
                                             "error-text.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build())
-                                            .fallback(FallbackConfig.builder().errorText("internal server error").build())
-                                            .build()),
+                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().errorText("internal server error").build())
+                                                    .build()),
                                     Map.entry(
                                             "unavailable-page-over-text.com",
                                             SiteConfig.builder()
-                                            .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                            .protection(ProtectionConfig.builder().disable(true).build())
-                                            .fallback(FallbackConfig.builder()
-                                                    .unavailablePage("fallback/unavailable_page.html")
-                                                    .unavailableText("service is unavailable")
-                                                    .build())
-                                            .build()),
+                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder()
+                                                            .unavailablePage("fallback/unavailable_page.html")
+                                                            .unavailableText("service is unavailable")
+                                                            .build())
+                                                    .build()),
                                     Map.entry(
                                             "error-page-over-text.com",
                                             SiteConfig.builder()
@@ -108,6 +121,13 @@ public class FallbackTest {
                                                             .errorPage("fallback/error_page.html")
                                                             .errorText("internal server error")
                                                             .build())
+                                                    .build()),
+                                    Map.entry(
+                                            "inherit-error.com",
+                                            SiteConfig.builder()
+                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().unavailableText("service is unavailable").build())
                                                     .build())
                             ))
                     .metrics(MetricsConfig.builder().enable(false).build())
@@ -121,7 +141,8 @@ public class FallbackTest {
                 .when_requesting("down.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
                 .then_expect_content("global-unavailable")
-                .then_channel_open();
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
 
         steps
                 .when_requesting("boom.com", "/")
@@ -136,7 +157,8 @@ public class FallbackTest {
                 .when_requesting("site3.de", "/")
                 .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
                 .then_expect_content("site3-unavailable")
-                .then_channel_open();
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "17");
     }
 
     @Test
@@ -160,7 +182,19 @@ public class FallbackTest {
         steps
                 .when_requesting("unavailable-page.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("<html>down</html>");
+                .then_expect_content("<html>down</html>")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "17");
+    }
+
+    @Test
+    public void testSiteFallbackUnavailablePageNotFound() {
+        steps
+                .when_requesting("non-existent-page.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("global-unavailable")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
     }
 
     @Test
@@ -168,7 +202,40 @@ public class FallbackTest {
         steps
                 .when_requesting("error-page.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("<html>error</html>");
+                .then_expect_content("<html>error</html>")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
+    }
+
+    @Test
+    public void testFallbackPageFromDiskFile(@TempDir Path tempDir) throws IOException {
+        Path page = tempDir.resolve("down.html");
+        Files.writeString(page, "<html>disk-down</html>");
+
+        ProxyConfig config = ProxyConfig.builder()
+                .listen(ListenConfig.builder()
+                        .ssl(SslConfig.builder()
+                                .keyPath("classpath:ssl/test.key")
+                                .certPath("classpath:ssl/test.crt")
+                                .build())
+                        .build())
+                .sites(Map.of("disk.com", SiteConfig.builder()
+                        .response(ResponseConfig.builder().status(503).text("ignored").build())
+                        .protection(ProtectionConfig.builder().disable(true).build())
+                        .fallback(FallbackConfig.builder()
+                                .unavailablePage(page.toAbsolutePath().toString())   // absolute disk path
+                                .build())
+                        .build()))
+                .metrics(MetricsConfig.builder().enable(false).build())
+                .build();
+
+        CompleteTest.Steps localSteps = new CompleteTest.Steps().given_initialized_proxy_with(config);
+        localSteps.when_requesting("disk.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("<html>disk-down</html>")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "22");
+        localSteps.finish_and_check_for_leaks();
     }
 
     @Test
@@ -176,7 +243,9 @@ public class FallbackTest {
         steps
                 .when_requesting("unavailable-text.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("service is unavailable");
+                .then_expect_content("service is unavailable")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "22");
     }
 
     @Test
@@ -184,7 +253,9 @@ public class FallbackTest {
         steps
                 .when_requesting("error-text.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("internal server error");
+                .then_expect_content("internal server error")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "21");
     }
 
     @Test
@@ -192,7 +263,9 @@ public class FallbackTest {
         steps
                 .when_requesting("unavailable-page-over-text.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("<html>down</html>");
+                .then_expect_content("<html>down</html>")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "17");
     }
 
     @Test
@@ -200,7 +273,19 @@ public class FallbackTest {
         steps
                 .when_requesting("error-page-over-text.com", "/")
                 .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("<html>error</html>");
+                .then_expect_content("<html>error</html>")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
+    }
+
+    @Test
+    public void testSiteFallbackInheritError() {
+        steps
+                .when_requesting("inherit-error.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .then_expect_content("global-error")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
+                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "12");
     }
 
     @AfterEach

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -223,15 +223,6 @@ public class FallbackTest {
         assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
     }
 
-
-    @Test
-    public void testPageStatusOverrideIsIgnored() {
-        init(merged(siteError(
-                ResponseConfig.builder().text("err page").status(501).build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "err page");
-    }
-
     @Test
     public void testOkPassesThrough() {
         init(merged(null));

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -452,10 +452,7 @@ public class FallbackTest {
     init(
         merged(
             siteUnavailable(
-                ResponseConfig.builder()
-                    .location("https://status.example/")
-                    .status(303)
-                    .build())));
+                ResponseConfig.builder().location("https://status.example/").status(303).build())));
     upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
     assertRedirect(SEE_OTHER, "https://status.example/");
   }
@@ -465,10 +462,7 @@ public class FallbackTest {
     FallbackConfig globalRedirect =
         FallbackConfig.builder()
             .unavailableResponse(
-                ResponseConfig.builder()
-                    .location("http://origin.example/data")
-                    .status(308)
-                    .build())
+                ResponseConfig.builder().location("http://origin.example/data").status(308).build())
             .build();
     FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
 

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -1,0 +1,210 @@
+package org.sensepitch.edge;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import net.serenitybdd.junit5.SerenityJUnit5Extension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+/**
+ * @author Raid Thabet
+ */
+@ExtendWith(SerenityJUnit5Extension.class)
+public class FallbackTest {
+
+    static final ProxyConfig CONFIG =
+            ProxyConfig.builder()
+                    .listen(
+                            ListenConfig.builder()
+                                    .ssl(
+                                            SslConfig.builder()
+                                                    .keyPath("classpath:ssl/test.key")
+                                                    .certPath("classpath:ssl/test.crt")
+                                                    .build())
+                                    .build())
+                    // global fallback -> inherited unless a site overrides a field
+                    .fallback(
+                            FallbackConfig.builder()
+                                    .unavailableText("global-unavailable")
+                                    .errorText("global-error")
+                                    .build())
+                    .sites(
+                            Map.ofEntries(
+                                    Map.entry(
+                                            "down.com",
+                                            SiteConfig.builder()
+                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .build()),
+                                    Map.entry(
+                                            "boom.com",
+                                            SiteConfig.builder()
+                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .build()),
+                                    Map.entry(
+                                            "site3.de",
+                                            SiteConfig.builder()
+                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder().unavailableText("site3-unavailable").build())
+                                                    .build()),
+                                    Map.entry(
+                                            "ok.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(200).text("real-body").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build()).build()),
+                                    Map.entry(
+                                            "notfound.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(404).text("real-404").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build()).build()),
+                                    Map.entry(
+                                            "unavailable-page.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build())
+                                            .fallback(FallbackConfig.builder().unavailablePage("fallback/unavailable_page.html").build())
+                                            .build()),
+                                    Map.entry(
+                                            "error-page.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build())
+                                            .fallback(FallbackConfig.builder().errorPage("fallback/error_page.html").build())
+                                            .build()),
+                                    Map.entry(
+                                            "unavailable-text.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build())
+                                            .fallback(FallbackConfig.builder().unavailableText("service is unavailable").build())
+                                            .build()),
+                                    Map.entry(
+                                            "error-text.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build())
+                                            .fallback(FallbackConfig.builder().errorText("internal server error").build())
+                                            .build()),
+                                    Map.entry(
+                                            "unavailable-page-over-text.com",
+                                            SiteConfig.builder()
+                                            .response(ResponseConfig.builder().status(503).text("ignored").build())
+                                            .protection(ProtectionConfig.builder().disable(true).build())
+                                            .fallback(FallbackConfig.builder()
+                                                    .unavailablePage("fallback/unavailable_page.html")
+                                                    .unavailableText("service is unavailable")
+                                                    .build())
+                                            .build()),
+                                    Map.entry(
+                                            "error-page-over-text.com",
+                                            SiteConfig.builder()
+                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
+                                                    .protection(ProtectionConfig.builder().disable(true).build())
+                                                    .fallback(FallbackConfig.builder()
+                                                            .errorPage("fallback/error_page.html")
+                                                            .errorText("internal server error")
+                                                            .build())
+                                                    .build())
+                            ))
+                    .metrics(MetricsConfig.builder().enable(false).build())
+                    .build();
+
+    CompleteTest.Steps steps = new CompleteTest.Steps().given_initialized_proxy_with(CONFIG);
+
+    @Test
+    public void testGlobalFalback() {
+        steps
+                .when_requesting("down.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("global-unavailable")
+                .then_channel_open();
+
+        steps
+                .when_requesting("boom.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .then_expect_content("global-error")
+                .then_channel_open();
+    }
+
+    @Test
+    public void testSiteFallback() {
+        steps
+                .when_requesting("site3.de", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("site3-unavailable")
+                .then_channel_open();
+    }
+
+    @Test
+    public void testOkPassesThrough() {
+        steps
+                .when_requesting("ok.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.OK)
+                .then_expect_content("real-body");
+    }
+
+    @Test
+    public void testNon5xxPassesThrough() {
+        steps
+                .when_requesting("notfound.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.NOT_FOUND)
+                .then_expect_content("real-404");
+    }
+
+    @Test
+    public void testSiteFallbackUnavailablePageFromClasspath() {
+        steps
+                .when_requesting("unavailable-page.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("<html>down</html>");
+    }
+
+    @Test
+    public void testSiteFallbackErrorPageFromClasspath() {
+        steps
+                .when_requesting("error-page.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .then_expect_content("<html>error</html>");
+    }
+
+    @Test
+    public void testSiteFallbackUnavailableText() {
+        steps
+                .when_requesting("unavailable-text.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("service is unavailable");
+    }
+
+    @Test
+    public void testSiteFallbackErrorText() {
+        steps
+                .when_requesting("error-text.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .then_expect_content("internal server error");
+    }
+
+    @Test
+    public void testSiteFallbackUnavailablePageOverText() {
+        steps
+                .when_requesting("unavailable-page-over-text.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
+                .then_expect_content("<html>down</html>");
+    }
+
+    @Test
+    public void testSiteFallbackErrorPageOverText() {
+        steps
+                .when_requesting("error-page-over-text.com", "/")
+                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+                .then_expect_content("<html>error</html>");
+    }
+
+    @AfterEach
+    void finish() {
+        steps.finish_and_check_for_leaks();
+    }
+}

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -176,6 +176,13 @@ public class FallbackTest {
     }
 
     @Test
+    public void redirectWithNon3xxStatusFails() {
+        assertThatThrownBy(() ->
+                ResponseConfig.builder().location("/elsewhere").status(200).build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void testGlobalUnavailable() {
         init(merged(null));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
@@ -209,6 +216,21 @@ public class FallbackTest {
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
         // NOT the bundled fallback/unavailable.html; the whole DEFAULTS slot (file included) was replaced.
         assertPage(SERVICE_UNAVAILABLE, "we are down");
+    }
+
+    @Test
+    public void testPageHonorsExplicitStatus() {
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().text("down for maintenance").status(200).build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(OK, "down for maintenance");
+    }
+
+    @Test
+    public void testPageWithoutStatusKeepsOriginStatus() {
+        init(merged(siteUnavailable(page("still down"))));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(SERVICE_UNAVAILABLE, "still down");
     }
 
     @Test

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -77,7 +77,7 @@ public class FallbackTest {
             ctx.write(msg, promise);
           }
         };
-    channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
+    channel = new EmbeddedChannel(capture, new Fallback(cfg).newHandler());
   }
 
   private void upstreamResponds(HttpResponseStatus status, String body) {
@@ -318,7 +318,7 @@ public class FallbackTest {
                 ResponseConfig.builder()
                     .file("classpath:fallback/non_existent_page.html")
                     .build()));
-    assertThatThrownBy(() -> new FallbackHandler(cfg))
+    assertThatThrownBy(() -> new Fallback(cfg))
         .isInstanceOf(UncheckedIOException.class)
         .hasMessageContaining("non_existent_page.html");
   }
@@ -425,9 +425,11 @@ public class FallbackTest {
   }
 
   @Test
-  public void testEmptySlotServesLastResortText() {
-    init(merged(siteUnavailable(ResponseConfig.builder().build())));
-    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-    assertPage(SERVICE_UNAVAILABLE, "Unknown problem occurred");
+  public void testEmptySlotHardFails() {
+    // an empty slot replaces the whole default slot, leaving no file and no text to serve
+    FallbackConfig cfg = merged(siteUnavailable(ResponseConfig.builder().build()));
+    assertThatThrownBy(() -> new Fallback(cfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("neither file nor text");
   }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -7,6 +7,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_IMPLEMENTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.PERMANENT_REDIRECT;
+import static io.netty.handler.codec.http.HttpResponseStatus.SEE_OTHER;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -150,8 +151,6 @@ public class FallbackTest {
     assertThat(cfg.unavailableResponse()).isNotNull();
     assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
     assertThat(cfg.unavailableResponse().file()).isNull();
-    assertThat(cfg.unavailableResponse().permanentRedirect()).isNull();
-    assertThat(cfg.unavailableResponse().temporaryRedirect()).isNull();
     assertThat(cfg.unavailableResponse().location()).isNull();
     assertThat(cfg.unavailableResponse().contentType()).isNull();
     assertThat(cfg.unavailableResponse().status()).isEqualTo(0);
@@ -185,7 +184,37 @@ public class FallbackTest {
   @Test
   public void redirectWithNon3xxStatusFails() {
     assertThatThrownBy(() -> ResponseConfig.builder().location("/elsewhere").status(200).build())
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("redirect status must be one of [301, 302, 303, 307, 308], was: 200");
+  }
+
+  /** 3xx, but not a code a {@code Location} header means anything for. */
+  @Test
+  public void redirectWithNonRedirect3xxStatusFails() {
+    assertThatThrownBy(() -> ResponseConfig.builder().location("/elsewhere").status(304).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("was: 304");
+    assertThatThrownBy(() -> ResponseConfig.builder().location("/elsewhere").status(305).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("was: 305");
+  }
+
+  @Test
+  public void pageStatusOutsideHttpRangeFails() {
+    assertThatThrownBy(() -> ResponseConfig.builder().text("hi").status(42).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("status must be 100..599, was: 42");
+  }
+
+  /** A page with no explicit status keeps the sentinel 0, meaning "inherit the origin status". */
+  @Test
+  public void pageWithoutStatusKeepsZeroSentinel() {
+    assertThat(page("down").status()).isZero();
+  }
+
+  @Test
+  public void redirectWithoutStatusNormalizesTo302() {
+    assertThat(ResponseConfig.builder().location("/elsewhere").build().status()).isEqualTo(302);
   }
 
   @Test
@@ -384,7 +413,10 @@ public class FallbackTest {
     init(
         merged(
             siteUnavailable(
-                ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
+                ResponseConfig.builder()
+                    .location("https://elsewhere.example/")
+                    .status(308)
+                    .build())));
     upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
     assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
   }
@@ -394,7 +426,10 @@ public class FallbackTest {
     init(
         merged(
             siteError(
-                ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
+                ResponseConfig.builder()
+                    .location("https://elsewhere.example/")
+                    .status(308)
+                    .build())));
     upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
     assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
   }
@@ -404,9 +439,25 @@ public class FallbackTest {
     init(
         merged(
             siteError(
-                ResponseConfig.builder().temporaryRedirect("https://elsewhere.example/").build())));
+                ResponseConfig.builder()
+                    .location("https://elsewhere.example/")
+                    .status(307)
+                    .build())));
     upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
     assertRedirect(TEMPORARY_REDIRECT, "https://elsewhere.example/");
+  }
+
+  @Test
+  public void testUnavailableSeeOtherRedirect() {
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .location("https://status.example/")
+                    .status(303)
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertRedirect(SEE_OTHER, "https://status.example/");
   }
 
   @Test
@@ -414,7 +465,10 @@ public class FallbackTest {
     FallbackConfig globalRedirect =
         FallbackConfig.builder()
             .unavailableResponse(
-                ResponseConfig.builder().permanentRedirect("http://origin.example/data").build())
+                ResponseConfig.builder()
+                    .location("http://origin.example/data")
+                    .status(308)
+                    .build())
             .build();
     FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
 
@@ -424,12 +478,22 @@ public class FallbackTest {
     assertPage(SERVICE_UNAVAILABLE, "SITE3: down for maintenance");
   }
 
+  /**
+   * An empty slot has neither a redirect target nor a page body. This is now rejected when the
+   * record is constructed, so such a slot can never reach {@link Fallback} to be merged at all.
+   */
   @Test
   public void testEmptySlotHardFails() {
-    // an empty slot replaces the whole default slot, leaving no file and no text to serve
-    FallbackConfig cfg = merged(siteUnavailable(ResponseConfig.builder().build()));
-    assertThatThrownBy(() -> new Fallback(cfg))
+    assertThatThrownBy(() -> ResponseConfig.builder().build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("neither file nor text");
+        .hasMessageContaining("response should be one of");
+  }
+
+  @Test
+  public void redirectAndPageInSameResponseRejected() {
+    assertThatThrownBy(
+            () -> ResponseConfig.builder().location("/elsewhere").text("we are down").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("response should be one of");
   }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -23,14 +23,12 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,355 +41,393 @@ import org.yaml.snakeyaml.nodes.Node;
  */
 public class FallbackTest {
 
-    private static final String HTML = "text/html; charset=UTF-8";
+  private static final String HTML = "text/html; charset=UTF-8";
 
-    private static final FallbackConfig GLOBAL =
-            FallbackConfig.builder()
-                    .unavailableResponse(page("global-unavailable"))
-                    .errorResponse(page("global-error"))
-                    .build();
+  private static final FallbackConfig GLOBAL =
+      FallbackConfig.builder()
+          .unavailableResponse(page("global-unavailable"))
+          .errorResponse(page("global-error"))
+          .build();
 
-    private EmbeddedChannel channel;
-    private Object messageWritten;
+  private EmbeddedChannel channel;
+  private Object messageWritten;
 
-    private static ResponseConfig page(String text) {
-        return ResponseConfig.builder().text(text).build();
+  private static ResponseConfig page(String text) {
+    return ResponseConfig.builder().text(text).build();
+  }
+
+  private static FallbackConfig siteUnavailable(ResponseConfig r) {
+    return FallbackConfig.builder().unavailableResponse(r).build();
+  }
+
+  private static FallbackConfig siteError(ResponseConfig r) {
+    return FallbackConfig.builder().errorResponse(r).build();
+  }
+
+  private static FallbackConfig merged(FallbackConfig site) {
+    return FallbackConfig.DEFAULTS.merge(GLOBAL).merge(site);
+  }
+
+  private void init(FallbackConfig cfg) {
+    ChannelOutboundHandler capture =
+        new ChannelOutboundHandlerAdapter() {
+          @Override
+          public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            messageWritten = msg;
+            ctx.write(msg, promise);
+          }
+        };
+    channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
+  }
+
+  private void upstreamResponds(HttpResponseStatus status, String body) {
+    messageWritten = null;
+    channel.writeOutbound(
+        new DefaultFullHttpResponse(
+            HTTP_1_1, status, Unpooled.copiedBuffer(body, StandardCharsets.UTF_8)));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (channel != null) {
+      channel.finishAndReleaseAll();
     }
+  }
 
-    private static FallbackConfig siteUnavailable(ResponseConfig r) {
-        return FallbackConfig.builder().unavailableResponse(r).build();
-    }
+  private void assertPage(HttpResponseStatus status, String body, String contentType) {
+    assertThat(messageWritten)
+        .isInstanceOfSatisfying(
+            FullHttpResponse.class,
+            r -> {
+              assertThat(r.status()).isEqualTo(status);
+              assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
+              assertThat(r.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(contentType);
+              assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH))
+                  .isEqualTo(String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
+            });
+  }
 
-    private static FallbackConfig siteError(ResponseConfig r) {
-        return FallbackConfig.builder().errorResponse(r).build();
-    }
+  private void assertPage(HttpResponseStatus status, String body) {
+    assertPage(status, body, HTML);
+  }
 
-    private static FallbackConfig merged(FallbackConfig site) {
-        return FallbackConfig.DEFAULTS.merge(GLOBAL).merge(site);
-    }
+  private void assertRedirect(HttpResponseStatus status, String location) {
+    assertThat(messageWritten)
+        .isInstanceOfSatisfying(
+            FullHttpResponse.class,
+            r -> {
+              assertThat(r.status()).isEqualTo(status);
+              assertThat(r.headers().get(HttpHeaderNames.LOCATION)).isEqualTo(location);
+              assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
+              assertThat(r.content().readableBytes()).isZero();
+            });
+  }
 
-    private void init(FallbackConfig cfg) {
-        ChannelOutboundHandler capture =
-                new ChannelOutboundHandlerAdapter() {
-                    @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                        messageWritten = msg;
-                        ctx.write(msg, promise);
-                    }
-                };
-        channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
-    }
+  private void assertPassThrough(HttpResponseStatus status, String body) {
+    assertThat(messageWritten)
+        .isInstanceOfSatisfying(
+            FullHttpResponse.class,
+            r -> {
+              assertThat(r.status()).isEqualTo(status);
+              assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
+            });
+  }
 
-    private void upstreamResponds(HttpResponseStatus status, String body) {
-        messageWritten = null;
-        channel.writeOutbound(
-                new DefaultFullHttpResponse(
-                        HTTP_1_1, status, Unpooled.copiedBuffer(body, StandardCharsets.UTF_8)));
-    }
+  private static FallbackConfig parse(String yaml) {
+    Node root = new Yaml().compose(new StringReader(yaml));
+    return RecordConstructor.construct(FallbackConfig.class, root);
+  }
 
-    @AfterEach
-    void tearDown() {
-        if (channel != null) {
-            channel.finishAndReleaseAll();
-        }
-    }
-
-    private void assertPage(HttpResponseStatus status, String body, String contentType) {
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        r -> {
-                            assertThat(r.status()).isEqualTo(status);
-                            assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
-                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(contentType);
-                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH))
-                                    .isEqualTo(String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
-                        });
-    }
-
-    private void assertPage(HttpResponseStatus status, String body) {
-        assertPage(status, body, HTML);
-    }
-
-    private void assertRedirect(HttpResponseStatus status, String location) {
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        r -> {
-                            assertThat(r.status()).isEqualTo(status);
-                            assertThat(r.headers().get(HttpHeaderNames.LOCATION)).isEqualTo(location);
-                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
-                            assertThat(r.content().readableBytes()).isZero();
-                        });
-    }
-
-    private void assertPassThrough(HttpResponseStatus status, String body) {
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        r -> {
-                            assertThat(r.status()).isEqualTo(status);
-                            assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
-                        });
-    }
-
-    private static FallbackConfig parse(String yaml) {
-        Node root = new Yaml().compose(new StringReader(yaml));
-        return RecordConstructor.construct(FallbackConfig.class, root);
-    }
-
-    @Test
-    public void partialConfigParsesSparse() {
-        FallbackConfig cfg = parse("""
+  @Test
+  public void partialConfigParsesSparse() {
+    FallbackConfig cfg =
+        parse(
+            """
             unavailableResponse:
                 text: site2 down
             """);
 
-        assertThat(cfg.unavailableResponse()).isNotNull();
-        assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
-        assertThat(cfg.unavailableResponse().file()).isNull();
-        assertThat(cfg.unavailableResponse().permanentRedirect()).isNull();
-        assertThat(cfg.unavailableResponse().temporaryRedirect()).isNull();
-        assertThat(cfg.unavailableResponse().location()).isNull();
-        assertThat(cfg.unavailableResponse().contentType()).isNull();
-        assertThat(cfg.unavailableResponse().status()).isEqualTo(0);
-        assertThat(cfg.errorResponse())
-                .as("slot not present in YAML must stay null, not be seeded from defaults")
-                .isNull();
-    }
+    assertThat(cfg.unavailableResponse()).isNotNull();
+    assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
+    assertThat(cfg.unavailableResponse().file()).isNull();
+    assertThat(cfg.unavailableResponse().permanentRedirect()).isNull();
+    assertThat(cfg.unavailableResponse().temporaryRedirect()).isNull();
+    assertThat(cfg.unavailableResponse().location()).isNull();
+    assertThat(cfg.unavailableResponse().contentType()).isNull();
+    assertThat(cfg.unavailableResponse().status()).isEqualTo(0);
+    assertThat(cfg.errorResponse())
+        .as("slot not present in YAML must stay null, not be seeded from defaults")
+        .isNull();
+  }
 
-    @Test
-    public void siteOverrideDoesNotBeatGlobal() {
-        FallbackConfig global = parse("errorResponse:\n  text: global error\n");
-        FallbackConfig site = parse("unavailableResponse:\n  text: site2 down\n");
+  @Test
+  public void siteOverrideDoesNotBeatGlobal() {
+    FallbackConfig global = parse("errorResponse:\n  text: global error\n");
+    FallbackConfig site = parse("unavailableResponse:\n  text: site2 down\n");
 
-        FallbackConfig resolved = FallbackConfig.DEFAULTS.merge(global).merge(site);
+    FallbackConfig resolved = FallbackConfig.DEFAULTS.merge(global).merge(site);
 
-        assertThat(resolved.unavailableResponse().text()).as("site override applies").isEqualTo("site2 down");
-        assertThat(resolved.errorResponse().text())
-                .as("global error slot must survive: the site never overrode it")
-                .isEqualTo("global error");
-    }
+    assertThat(resolved.unavailableResponse().text())
+        .as("site override applies")
+        .isEqualTo("site2 down");
+    assertThat(resolved.errorResponse().text())
+        .as("global error slot must survive: the site never overrode it")
+        .isEqualTo("global error");
+  }
 
-    @Test
-    public void redirectAndPageInSameResponseFailsToParse() {
-        assertThatThrownBy(() -> parse("unavailableResponse:\n  location: /elsewhere\n  text: hi\n"))
-                .rootCause()
-                .isInstanceOf(IllegalArgumentException.class);
-    }
+  @Test
+  public void redirectAndPageInSameResponseFailsToParse() {
+    assertThatThrownBy(() -> parse("unavailableResponse:\n  location: /elsewhere\n  text: hi\n"))
+        .rootCause()
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
-    @Test
-    public void redirectWithNon3xxStatusFails() {
-        assertThatThrownBy(() ->
-                ResponseConfig.builder().location("/elsewhere").status(200).build())
-                .isInstanceOf(IllegalArgumentException.class);
-    }
+  @Test
+  public void redirectWithNon3xxStatusFails() {
+    assertThatThrownBy(() -> ResponseConfig.builder().location("/elsewhere").status(200).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
-    @Test
-    public void testGlobalUnavailable() {
-        init(merged(null));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "global-unavailable");
-    }
+  @Test
+  public void testGlobalUnavailable() {
+    init(merged(null));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "global-unavailable");
+  }
 
-    @Test
-    public void testGlobalError() {
-        init(merged(null));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "global-error");
-    }
+  @Test
+  public void testGlobalError() {
+    init(merged(null));
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertPage(INTERNAL_SERVER_ERROR, "global-error");
+  }
 
-    @Test
-    public void testSiteOverridesUnavailable() {
-        init(merged(siteUnavailable(page("site3-unavailable"))));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "site3-unavailable");
-    }
+  @Test
+  public void testSiteOverridesUnavailable() {
+    init(merged(siteUnavailable(page("site3-unavailable"))));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "site3-unavailable");
+  }
 
-    @Test
-    public void testSiteInheritsGlobalError() {
-        init(merged(siteUnavailable(page("site is down"))));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "global-error");
-    }
+  @Test
+  public void testSiteInheritsGlobalError() {
+    init(merged(siteUnavailable(page("site is down"))));
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertPage(INTERNAL_SERVER_ERROR, "global-error");
+  }
 
-    @Test
-    public void testSiteTextSlotDropsDefaultFile() {
-        init(FallbackConfig.DEFAULTS.merge(siteUnavailable(page("we are down"))));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        // NOT the bundled fallback/unavailable.html; the whole DEFAULTS slot (file included) was replaced.
-        assertPage(SERVICE_UNAVAILABLE, "we are down");
-    }
+  @Test
+  public void testSiteTextSlotDropsDefaultFile() {
+    init(FallbackConfig.DEFAULTS.merge(siteUnavailable(page("we are down"))));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    // NOT the bundled fallback/unavailable.html; the whole DEFAULTS slot (file included) was
+    // replaced.
+    assertPage(SERVICE_UNAVAILABLE, "we are down");
+  }
 
-    @Test
-    public void testPageHonorsExplicitStatus() {
-        init(merged(siteUnavailable(
+  @Test
+  public void testPageHonorsExplicitStatus() {
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().text("down for maintenance").status(200).build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(OK, "down for maintenance");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(OK, "down for maintenance");
+  }
 
-    @Test
-    public void testPageWithoutStatusKeepsOriginStatus() {
-        init(merged(siteUnavailable(page("still down"))));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "still down");
-    }
+  @Test
+  public void testPageWithoutStatusKeepsOriginStatus() {
+    init(merged(siteUnavailable(page("still down"))));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "still down");
+  }
 
-    @Test
-    public void testCustomContentType() {
-        init(merged(siteUnavailable(
-                ResponseConfig.builder().text("{\"down\":true}").contentType("application/json").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
-    }
+  @Test
+  public void testCustomContentType() {
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .text("{\"down\":true}")
+                    .contentType("application/json")
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
+  }
 
-    @Test
-    public void testOkPassesThrough() {
-        init(merged(null));
-        upstreamResponds(OK, "real-body");
-        assertPassThrough(OK, "real-body");
-    }
+  @Test
+  public void testOkPassesThrough() {
+    init(merged(null));
+    upstreamResponds(OK, "real-body");
+    assertPassThrough(OK, "real-body");
+  }
 
-    @Test
-    public void testNon5xxPassesThrough() {
-        init(merged(null));
-        upstreamResponds(NOT_FOUND, "real-404");
-        assertPassThrough(NOT_FOUND, "real-404");
-    }
-    
-    @Test
-    public void testOtherServerErrorStatusesPassThroughUnmodified() {
-        init(merged(null));
-        upstreamResponds(NOT_IMPLEMENTED, "real-501");
-        assertPassThrough(NOT_IMPLEMENTED, "real-501");
-    }
+  @Test
+  public void testNon5xxPassesThrough() {
+    init(merged(null));
+    upstreamResponds(NOT_FOUND, "real-404");
+    assertPassThrough(NOT_FOUND, "real-404");
+  }
 
-    @Test
-    public void testUnavailablePageFromClasspath() {
-        init(merged(siteUnavailable(
-                ResponseConfig.builder().file("classpath:fallback/unavailable_page.html").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
-    }
+  @Test
+  public void testOtherServerErrorStatusesPassThroughUnmodified() {
+    init(merged(null));
+    upstreamResponds(NOT_IMPLEMENTED, "real-501");
+    assertPassThrough(NOT_IMPLEMENTED, "real-501");
+  }
 
-    @Test
-    public void testFileAndTextTogetherRejected() {
-        assertThatThrownBy(() -> ResponseConfig.builder()
-                .file("classpath:fallback/unavailable_page.html")
-                .text("service is unavailable")
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("not both");
-    }
+  @Test
+  public void testUnavailablePageFromClasspath() {
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .file("classpath:fallback/unavailable_page.html")
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
+  }
 
-    @Test
-    public void testErrorPageFromClasspath() {
-        init(merged(siteError(
+  @Test
+  public void testFileAndTextTogetherRejected() {
+    assertThatThrownBy(
+            () ->
+                ResponseConfig.builder()
+                    .file("classpath:fallback/unavailable_page.html")
+                    .text("service is unavailable")
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not both");
+  }
+
+  @Test
+  public void testErrorPageFromClasspath() {
+    init(
+        merged(
+            siteError(
                 ResponseConfig.builder().file("classpath:fallback/error_page.html").build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
-    }
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
+  }
 
-    @Test
-    public void testMissingFileHardFails() {
-        FallbackConfig cfg = merged(siteUnavailable(
-                ResponseConfig.builder().file("classpath:fallback/non_existent_page.html").build()));
-        assertThatThrownBy(() -> new FallbackHandler(cfg))
-                .isInstanceOf(UncheckedIOException.class)
-                .hasMessageContaining("non_existent_page.html");
-    }
+  @Test
+  public void testMissingFileHardFails() {
+    FallbackConfig cfg =
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .file("classpath:fallback/non_existent_page.html")
+                    .build()));
+    assertThatThrownBy(() -> new FallbackHandler(cfg))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("non_existent_page.html");
+  }
 
-    @Test
-    public void testSchemelessResolvesViaClasspath() {
-        // no scheme, not on disk -> falls through to the classpath resource
-        init(merged(siteUnavailable(
+  @Test
+  public void testSchemelessResolvesViaClasspath() {
+    // no scheme, not on disk -> falls through to the classpath resource
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().file("fallback/unavailable_page.html").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
+  }
 
-    @Test
-    public void testSchemelessPrefersFilesystem(@TempDir Path tempDir) throws IOException {
-        Path pageFile = tempDir.resolve("down.html");
-        Files.writeString(pageFile, "<html>disk-first</html>");
-        // no scheme, exists on disk -> filesystem wins over any classpath resource
-        init(merged(siteUnavailable(
+  @Test
+  public void testSchemelessPrefersFilesystem(@TempDir Path tempDir) throws IOException {
+    Path pageFile = tempDir.resolve("down.html");
+    Files.writeString(pageFile, "<html>disk-first</html>");
+    // no scheme, exists on disk -> filesystem wins over any classpath resource
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().file(pageFile.toAbsolutePath().toString()).build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>disk-first</html>");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>disk-first</html>");
+  }
 
-    @Test
-    public void testUnavailablePageFromDiskFile(@TempDir Path tempDir) throws IOException {
-        Path pageFile = tempDir.resolve("down.html");
-        Files.writeString(pageFile, "<html>disk-down</html>");
+  @Test
+  public void testUnavailablePageFromDiskFile(@TempDir Path tempDir) throws IOException {
+    Path pageFile = tempDir.resolve("down.html");
+    Files.writeString(pageFile, "<html>disk-down</html>");
 
-        init(merged(siteUnavailable(
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().file("file:" + pageFile.toAbsolutePath()).build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>disk-down</html>");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>disk-down</html>");
+  }
 
-    @Test
-    public void testUnavailableRedirectDefaults302() {
-        init(merged(siteUnavailable(
-                ResponseConfig.builder().location("https://status.example/").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertRedirect(FOUND, "https://status.example/");
-    }
+  @Test
+  public void testUnavailableRedirectDefaults302() {
+    init(
+        merged(
+            siteUnavailable(ResponseConfig.builder().location("https://status.example/").build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertRedirect(FOUND, "https://status.example/");
+  }
 
-    @Test
-    public void testUnavailableRedirectHonorsExplicitStatus() {
-        init(merged(siteUnavailable(
+  @Test
+  public void testUnavailableRedirectHonorsExplicitStatus() {
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().location("https://status.example/").status(301).build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertRedirect(MOVED_PERMANENTLY, "https://status.example/");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertRedirect(MOVED_PERMANENTLY, "https://status.example/");
+  }
 
-    @Test
-    public void testUnavailablePermanentRedirect() {
-        init(merged(siteUnavailable(
+  @Test
+  public void testUnavailablePermanentRedirect() {
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
+  }
 
-    @Test
-    public void testErrorPermanentRedirect() {
-        init(merged(siteError(
+  @Test
+  public void testErrorPermanentRedirect() {
+    init(
+        merged(
+            siteError(
                 ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
-    }
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
+  }
 
-    @Test
-    public void testErrorTemporaryRedirect() {
-        init(merged(siteError(
+  @Test
+  public void testErrorTemporaryRedirect() {
+    init(
+        merged(
+            siteError(
                 ResponseConfig.builder().temporaryRedirect("https://elsewhere.example/").build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertRedirect(TEMPORARY_REDIRECT, "https://elsewhere.example/");
-    }
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertRedirect(TEMPORARY_REDIRECT, "https://elsewhere.example/");
+  }
 
-    @Test
-    public void testSitePageReplacesGlobalRedirect() {
-        FallbackConfig globalRedirect =
-                FallbackConfig.builder()
-                        .unavailableResponse(
-                                ResponseConfig.builder().permanentRedirect("http://origin.example/data").build())
-                        .build();
-        FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
+  @Test
+  public void testSitePageReplacesGlobalRedirect() {
+    FallbackConfig globalRedirect =
+        FallbackConfig.builder()
+            .unavailableResponse(
+                ResponseConfig.builder().permanentRedirect("http://origin.example/data").build())
+            .build();
+    FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
 
-        init(FallbackConfig.DEFAULTS.merge(globalRedirect).merge(site));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        // page served, no Location header logic involved; the global redirect is gone entirely
-        assertPage(SERVICE_UNAVAILABLE, "SITE3: down for maintenance");
-    }
+    init(FallbackConfig.DEFAULTS.merge(globalRedirect).merge(site));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    // page served, no Location header logic involved; the global redirect is gone entirely
+    assertPage(SERVICE_UNAVAILABLE, "SITE3: down for maintenance");
+  }
 
-    @Test
-    public void testEmptySlotServesLastResortText() {
-        init(merged(siteUnavailable(ResponseConfig.builder().build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "Unknown problem occurred");
-    }
+  @Test
+  public void testEmptySlotServesLastResortText() {
+    init(merged(siteUnavailable(ResponseConfig.builder().build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "Unknown problem occurred");
+  }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -1,295 +1,320 @@
 package org.sensepitch.edge;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import net.serenitybdd.junit5.SerenityJUnit5Extension;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
+ * Tests {@link FallbackHandler} against the aggregated {@link FullHttpResponse} shape (as the
+ * in-process {@code response:} stub produces); the streamed shape is covered in
+ * {@link FallbackStreamingTest}. Each test uses the config {@code SiteSelector} would build
+ * (DEFAULT overridden by global overridden by site) so the layering is exercised too.
+ *
  * @author Raid Thabet
  */
-@ExtendWith(SerenityJUnit5Extension.class)
 public class FallbackTest {
 
-    static final ProxyConfig CONFIG =
-            ProxyConfig.builder()
-                    .listen(
-                            ListenConfig.builder()
-                                    .ssl(
-                                            SslConfig.builder()
-                                                    .keyPath("classpath:ssl/test.key")
-                                                    .certPath("classpath:ssl/test.crt")
-                                                    .build())
-                                    .build())
-                    // global fallback -> inherited unless a site overrides a field
-                    .fallback(
-                            FallbackConfig.builder()
-                                    .unavailableText("global-unavailable")
-                                    .errorText("global-error")
-                                    .build())
-                    .sites(
-                            Map.ofEntries(
-                                    Map.entry(
-                                            "down.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .build()),
-                                    Map.entry(
-                                            "boom.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .build()),
-                                    Map.entry(
-                                            "site3.de",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().unavailableText("site3-unavailable").build())
-                                                    .build()),
-                                    Map.entry(
-                                            "ok.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(200).text("real-body").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build()).build()),
-                                    Map.entry(
-                                            "notfound.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(404).text("real-404").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build()).build()),
-                                    Map.entry(
-                                            "unavailable-page.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().unavailablePage("fallback/unavailable_page.html").build())
-                                                    .build()),
-                                    Map.entry(
-                                            "non-existent-page.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().unavailablePage("fallback/non_existent_page.html").build())
-                                                    .build()
-                                    ),
-                                    Map.entry(
-                                            "error-page.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().errorPage("fallback/error_page.html").build())
-                                                    .build()),
-                                    Map.entry(
-                                            "unavailable-text.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().unavailableText("service is unavailable").build())
-                                                    .build()),
-                                    Map.entry(
-                                            "error-text.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().errorText("internal server error").build())
-                                                    .build()),
-                                    Map.entry(
-                                            "unavailable-page-over-text.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(503).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder()
-                                                            .unavailablePage("fallback/unavailable_page.html")
-                                                            .unavailableText("service is unavailable")
-                                                            .build())
-                                                    .build()),
-                                    Map.entry(
-                                            "error-page-over-text.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder()
-                                                            .errorPage("fallback/error_page.html")
-                                                            .errorText("internal server error")
-                                                            .build())
-                                                    .build()),
-                                    Map.entry(
-                                            "inherit-error.com",
-                                            SiteConfig.builder()
-                                                    .response(ResponseConfig.builder().status(500).text("ignored").build())
-                                                    .protection(ProtectionConfig.builder().disable(true).build())
-                                                    .fallback(FallbackConfig.builder().unavailableText("service is unavailable").build())
-                                                    .build())
-                            ))
-                    .metrics(MetricsConfig.builder().enable(false).build())
+    private static final FallbackConfig GLOBAL =
+            FallbackConfig.builder()
+                    .unavailableText("global-unavailable") // 18 bytes
+                    .errorText("global-error") // 12 bytes
                     .build();
 
-    CompleteTest.Steps steps = new CompleteTest.Steps().given_initialized_proxy_with(CONFIG);
+    private EmbeddedChannel channel;
+    private Object messageWritten;
 
-    @Test
-    public void testGlobalFalback() {
-        steps
-                .when_requesting("down.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("global-unavailable")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
+    /**
+     * Mirrors {@code SiteSelector}: DEFAULT overridden by global, overridden by the site.
+     */
+    private static FallbackConfig merged(FallbackConfig site) {
+        return FallbackConfig.DEFAULT.merge(GLOBAL).merge(site);
+    }
 
-        steps
-                .when_requesting("boom.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("global-error")
-                .then_channel_open();
+    private void init(FallbackConfig cfg) {
+        ChannelOutboundHandler capture =
+                new ChannelOutboundHandlerAdapter() {
+                    @Override
+                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                        messageWritten = msg;
+                        ctx.write(msg, promise);
+                    }
+                };
+        channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
+    }
+
+    /**
+     * Sends one aggregated upstream response of the given status through the handler.
+     */
+    private void upstreamResponds(HttpResponseStatus status, String body) {
+        messageWritten = null;
+        channel.writeOutbound(
+                new DefaultFullHttpResponse(
+                        HTTP_1_1, status, Unpooled.copiedBuffer(body, StandardCharsets.UTF_8)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channel != null) {
+            channel.finishAndReleaseAll();
+        }
     }
 
     @Test
-    public void testSiteFallback() {
-        steps
-                .when_requesting("site3.de", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("site3-unavailable")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "17");
+    public void testGlobalUnavailable() {
+        init(merged(null));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.status()).isEqualTo(SERVICE_UNAVAILABLE);
+                            assertThat(response.content().toString(StandardCharsets.UTF_8))
+                                    .isEqualTo("global-unavailable");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE))
+                                    .isEqualTo("text/html; charset=UTF-8");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+                        });
+    }
+
+    @Test
+    public void testGlobalError() {
+        init(merged(null));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.status()).isEqualTo(INTERNAL_SERVER_ERROR);
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("global-error");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
+                        });
+    }
+
+    @Test
+    public void testSiteOverridesUnavailableText() {
+        init(merged(FallbackConfig.builder().unavailableText("site3-unavailable").build()));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8))
+                                    .isEqualTo("site3-unavailable");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("17");
+                        });
     }
 
     @Test
     public void testOkPassesThrough() {
-        steps
-                .when_requesting("ok.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.OK)
-                .then_expect_content("real-body");
+        init(merged(null));
+        upstreamResponds(OK, "real-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.status()).isEqualTo(OK);
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("real-body");
+                        });
     }
 
     @Test
     public void testNon5xxPassesThrough() {
-        steps
-                .when_requesting("notfound.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.NOT_FOUND)
-                .then_expect_content("real-404");
+        init(merged(null));
+        upstreamResponds(NOT_FOUND, "real-404");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.status()).isEqualTo(NOT_FOUND);
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("real-404");
+                        });
     }
 
     @Test
-    public void testSiteFallbackUnavailablePageFromClasspath() {
-        steps
-                .when_requesting("unavailable-page.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("<html>down</html>")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "17");
+    public void testUnavailablePageFromClasspath() {
+        init(merged(FallbackConfig.builder()
+                        .unavailablePage("fallback/unavailable_page.html")
+                        .unavailableText("service is unavailable")
+                        .build()
+                )
+        );
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>down</html>");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE))
+                                    .isEqualTo("text/html; charset=UTF-8");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("17");
+                        });
     }
 
     @Test
-    public void testSiteFallbackUnavailablePageNotFound() {
-        steps
-                .when_requesting("non-existent-page.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("global-unavailable")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
+    public void testUnavailablePageNotFoundFallsBackToGlobalText() {
+        init(merged(FallbackConfig.builder().unavailablePage("fallback/non_existent_page.html").build()));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("global-unavailable");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+                        });
     }
 
     @Test
-    public void testSiteFallbackErrorPageFromClasspath() {
-        steps
-                .when_requesting("error-page.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("<html>error</html>")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
+    public void testUnavailablePageNotFoundFallsBackToSiteText() {
+        init(merged(FallbackConfig.builder()
+                        .unavailablePage("fallback/non_existent_page.html")
+                        .unavailableText("service unavailable")
+                        .build()
+                )
+        );
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("service unavailable");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("19");
+                        });
     }
 
     @Test
-    public void testFallbackPageFromDiskFile(@TempDir Path tempDir) throws IOException {
+    public void testErrorPageFromClasspath() {
+        init(merged(FallbackConfig.builder()
+                        .errorPage("fallback/error_page.html")
+                        .errorText("internal server error")
+                        .build()
+                )
+        );
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>error</html>");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+                        });
+    }
+
+    @Test
+    public void testUnavailablePageFromDiskFile(@TempDir Path tempDir) throws IOException {
         Path page = tempDir.resolve("down.html");
         Files.writeString(page, "<html>disk-down</html>");
 
-        ProxyConfig config = ProxyConfig.builder()
-                .listen(ListenConfig.builder()
-                        .ssl(SslConfig.builder()
-                                .keyPath("classpath:ssl/test.key")
-                                .certPath("classpath:ssl/test.crt")
-                                .build())
-                        .build())
-                .sites(Map.of("disk.com", SiteConfig.builder()
-                        .response(ResponseConfig.builder().status(503).text("ignored").build())
-                        .protection(ProtectionConfig.builder().disable(true).build())
-                        .fallback(FallbackConfig.builder()
-                                .unavailablePage(page.toAbsolutePath().toString())   // absolute disk path
-                                .build())
-                        .build()))
-                .metrics(MetricsConfig.builder().enable(false).build())
-                .build();
-
-        CompleteTest.Steps localSteps = new CompleteTest.Steps().given_initialized_proxy_with(config);
-        localSteps.when_requesting("disk.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("<html>disk-down</html>")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "22");
-        localSteps.finish_and_check_for_leaks();
+        init(merged(FallbackConfig.builder()
+                        .unavailablePage(page.toAbsolutePath().toString())
+                        .unavailableText("service is unavailable")
+                        .build()
+                )
+        );
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>disk-down</html>");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("22");
+                        });
     }
 
     @Test
-    public void testSiteFallbackUnavailableText() {
-        steps
-                .when_requesting("unavailable-text.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("service is unavailable")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "22");
+    public void testSiteUnavailableText() {
+        init(merged(FallbackConfig.builder().unavailableText("service is unavailable").build()));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("service is unavailable");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("22");
+                        });
     }
 
     @Test
-    public void testSiteFallbackErrorText() {
-        steps
-                .when_requesting("error-text.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("internal server error")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "21");
+    public void testSiteErrorText() {
+        init(merged(FallbackConfig.builder().errorText("internal server error").build()));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("internal server error");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("21");
+                        });
     }
 
     @Test
-    public void testSiteFallbackUnavailablePageOverText() {
-        steps
-                .when_requesting("unavailable-page-over-text.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.SERVICE_UNAVAILABLE)
-                .then_expect_content("<html>down</html>")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "17");
+    public void testUnavailablePageBeatsText() {
+        init(
+                merged(
+                        FallbackConfig.builder()
+                                .unavailablePage("fallback/unavailable_page.html")
+                                .unavailableText("service is unavailable")
+                                .build()));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>down</html>");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("17");
+                        });
     }
 
     @Test
-    public void testSiteFallbackErrorPageOverText() {
-        steps
-                .when_requesting("error-page-over-text.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("<html>error</html>")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "18");
+    public void testErrorPageBeatsText() {
+        init(
+                merged(
+                        FallbackConfig.builder()
+                                .errorPage("fallback/error_page.html")
+                                .errorText("internal server error")
+                                .build()));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>error</html>");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
+                        });
     }
 
     @Test
-    public void testSiteFallbackInheritError() {
-        steps
-                .when_requesting("inherit-error.com", "/")
-                .then_the_response_status_is(HttpResponseStatus.INTERNAL_SERVER_ERROR)
-                .then_expect_content("global-error")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8")
-                .then_the_response_header_is(HttpHeaderNames.CONTENT_LENGTH, "12");
-    }
-
-    @AfterEach
-    void finish() {
-        steps.finish_and_check_for_leaks();
+    public void testSiteInheritsGlobalError() {
+        init(merged(FallbackConfig.builder().unavailableText("service is unavailable").build()));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        response -> {
+                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("global-error");
+                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
+                        });
     }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -19,6 +19,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +27,9 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.sensepitch.edge.config.RecordConstructor;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Node;
 
 /**
  * Tests {@link FallbackHandler} against the aggregated {@link FullHttpResponse} shape (as the
@@ -50,7 +54,7 @@ public class FallbackTest {
      * Mirrors {@code SiteSelector}: DEFAULT overridden by global, overridden by the site.
      */
     private static FallbackConfig merged(FallbackConfig site) {
-        return FallbackConfig.DEFAULT.merge(GLOBAL).merge(site);
+        return FallbackConfig.DEFAULTS.merge(GLOBAL).merge(site);
     }
 
     private void init(FallbackConfig cfg) {
@@ -80,6 +84,43 @@ public class FallbackTest {
         if (channel != null) {
             channel.finishAndReleaseAll();
         }
+    }
+
+    // --- config parse + merge: root cause and regression for the DEFAULT-seeding clobber ---
+
+    private static FallbackConfig parse(String yaml) {
+        Node root = new Yaml().compose(new StringReader(yaml));
+        return RecordConstructor.construct(FallbackConfig.class, root);
+    }
+
+    /** A partial config must parse sparse: fields the YAML never set stay null, not seeded from defaults. */
+    @Test
+    public void partialConfigParsesSparse() {
+        FallbackConfig cfg = parse("unavailableText: site2 down\n");
+
+        assertThat(cfg.unavailableText()).isEqualTo("site2 down");
+        assertThat(cfg.errorText())
+                .as("field not present in YAML must stay null, not be seeded from defaults")
+                .isNull();
+        assertThat(cfg.errorPage()).isNull();
+        assertThat(cfg.unavailablePage()).isNull();
+    }
+
+    /** A site overriding one field must not wipe a global override on another. */
+    @Test
+    public void siteOverrideDoesNotClobberGlobal() {
+        FallbackConfig global = parse("errorText: global error\n");
+        FallbackConfig site = parse("unavailableText: site2 down\n");
+
+        // Mirrors SiteSelector.constructFallbackSupplier resolution order.
+        FallbackConfig resolved = FallbackConfig.DEFAULTS.merge(global).merge(site);
+
+        assertThat(resolved.unavailablePage()).isEqualTo("fallback/unavailable.html");
+        assertThat(resolved.errorPage()).isEqualTo("fallback/error.html");
+        assertThat(resolved.unavailableText()).as("site override applies").isEqualTo("site2 down");
+        assertThat(resolved.errorText())
+                .as("global error text must survive: the site never overrode it")
+                .isEqualTo("global error");
     }
 
     @Test

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -1,11 +1,16 @@
 package org.sensepitch.edge;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.MOVED_PERMANENTLY;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -32,27 +37,33 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Node;
 
 /**
- * Tests {@link FallbackHandler} against the aggregated {@link FullHttpResponse} shape (as the
- * in-process {@code response:} stub produces); the streamed shape is covered in
- * {@link FallbackStreamingTest}. Each test uses the config {@code SiteSelector} would build
- * (DEFAULT overridden by global overridden by site) so the layering is exercised too.
- *
  * @author Raid Thabet
  */
 public class FallbackTest {
 
+    private static final String HTML = "text/html; charset=UTF-8";
+
     private static final FallbackConfig GLOBAL =
             FallbackConfig.builder()
-                    .unavailableText("global-unavailable") // 18 bytes
-                    .errorText("global-error") // 12 bytes
+                    .unavailableResponse(page("global-unavailable"))
+                    .errorResponse(page("global-error"))
                     .build();
 
     private EmbeddedChannel channel;
     private Object messageWritten;
 
-    /**
-     * Mirrors {@code SiteSelector}: DEFAULT overridden by global, overridden by the site.
-     */
+    private static ResponseConfig page(String text) {
+        return ResponseConfig.builder().text(text).build();
+    }
+
+    private static FallbackConfig siteUnavailable(ResponseConfig r) {
+        return FallbackConfig.builder().unavailableResponse(r).build();
+    }
+
+    private static FallbackConfig siteError(ResponseConfig r) {
+        return FallbackConfig.builder().errorResponse(r).build();
+    }
+
     private static FallbackConfig merged(FallbackConfig site) {
         return FallbackConfig.DEFAULTS.merge(GLOBAL).merge(site);
     }
@@ -69,9 +80,6 @@ public class FallbackTest {
         channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
     }
 
-    /**
-     * Sends one aggregated upstream response of the given status through the handler.
-     */
     private void upstreamResponds(HttpResponseStatus status, String body) {
         messageWritten = null;
         channel.writeOutbound(
@@ -86,276 +94,239 @@ public class FallbackTest {
         }
     }
 
-    // --- config parse + merge: root cause and regression for the DEFAULT-seeding clobber ---
+    private void assertPage(HttpResponseStatus status, String body, String contentType) {
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        r -> {
+                            assertThat(r.status()).isEqualTo(status);
+                            assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
+                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(contentType);
+                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH))
+                                    .isEqualTo(String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
+                        });
+    }
+
+    private void assertPage(HttpResponseStatus status, String body) {
+        assertPage(status, body, HTML);
+    }
+
+    private void assertRedirect(HttpResponseStatus status, String location) {
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        r -> {
+                            assertThat(r.status()).isEqualTo(status);
+                            assertThat(r.headers().get(HttpHeaderNames.LOCATION)).isEqualTo(location);
+                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
+                            assertThat(r.content().readableBytes()).isZero();
+                        });
+    }
+
+    private void assertPassThrough(HttpResponseStatus status, String body) {
+        assertThat(messageWritten)
+                .isInstanceOfSatisfying(
+                        FullHttpResponse.class,
+                        r -> {
+                            assertThat(r.status()).isEqualTo(status);
+                            assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
+                        });
+    }
 
     private static FallbackConfig parse(String yaml) {
         Node root = new Yaml().compose(new StringReader(yaml));
         return RecordConstructor.construct(FallbackConfig.class, root);
     }
 
-    /** A partial config must parse sparse: fields the YAML never set stay null, not seeded from defaults. */
     @Test
     public void partialConfigParsesSparse() {
-        FallbackConfig cfg = parse("unavailableText: site2 down\n");
+        FallbackConfig cfg = parse("unavailableResponse:\n  text: site2 down\n");
 
-        assertThat(cfg.unavailableText()).isEqualTo("site2 down");
-        assertThat(cfg.errorText())
-                .as("field not present in YAML must stay null, not be seeded from defaults")
+        assertThat(cfg.unavailableResponse()).isNotNull();
+        assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
+        assertThat(cfg.unavailableResponse().file()).isNull();
+        assertThat(cfg.unavailableResponse().permanentRedirect()).isNull();
+        assertThat(cfg.unavailableResponse().temporaryRedirect()).isNull();
+        assertThat(cfg.unavailableResponse().location()).isNull();
+        assertThat(cfg.unavailableResponse().contentType()).isNull();
+        assertThat(cfg.unavailableResponse().status()).isEqualTo(0);
+        assertThat(cfg.errorResponse())
+                .as("slot not present in YAML must stay null, not be seeded from defaults")
                 .isNull();
-        assertThat(cfg.errorPage()).isNull();
-        assertThat(cfg.unavailablePage()).isNull();
     }
 
-    /** A site overriding one field must not wipe a global override on another. */
     @Test
-    public void siteOverrideDoesNotClobberGlobal() {
-        FallbackConfig global = parse("errorText: global error\n");
-        FallbackConfig site = parse("unavailableText: site2 down\n");
+    public void siteOverrideDoesNotBeatGlobal() {
+        FallbackConfig global = parse("errorResponse:\n  text: global error\n");
+        FallbackConfig site = parse("unavailableResponse:\n  text: site2 down\n");
 
-        // Mirrors SiteSelector.constructFallbackSupplier resolution order.
         FallbackConfig resolved = FallbackConfig.DEFAULTS.merge(global).merge(site);
 
-        assertThat(resolved.unavailablePage()).isEqualTo("fallback/unavailable.html");
-        assertThat(resolved.errorPage()).isEqualTo("fallback/error.html");
-        assertThat(resolved.unavailableText()).as("site override applies").isEqualTo("site2 down");
-        assertThat(resolved.errorText())
-                .as("global error text must survive: the site never overrode it")
+        assertThat(resolved.unavailableResponse().text()).as("site override applies").isEqualTo("site2 down");
+        assertThat(resolved.errorResponse().text())
+                .as("global error slot must survive: the site never overrode it")
                 .isEqualTo("global error");
+    }
+
+    @Test
+    public void redirectAndPageInSameResponseFailsToParse() {
+        assertThatThrownBy(() -> parse("unavailableResponse:\n  location: /elsewhere\n  text: hi\n"))
+                .rootCause()
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void testGlobalUnavailable() {
         init(merged(null));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.status()).isEqualTo(SERVICE_UNAVAILABLE);
-                            assertThat(response.content().toString(StandardCharsets.UTF_8))
-                                    .isEqualTo("global-unavailable");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE))
-                                    .isEqualTo("text/html; charset=UTF-8");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
-                        });
+        assertPage(SERVICE_UNAVAILABLE, "global-unavailable");
     }
 
     @Test
     public void testGlobalError() {
         init(merged(null));
         upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.status()).isEqualTo(INTERNAL_SERVER_ERROR);
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("global-error");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
-                        });
+        assertPage(INTERNAL_SERVER_ERROR, "global-error");
     }
 
     @Test
-    public void testSiteOverridesUnavailableText() {
-        init(merged(FallbackConfig.builder().unavailableText("site3-unavailable").build()));
+    public void testSiteOverridesUnavailable() {
+        init(merged(siteUnavailable(page("site3-unavailable"))));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8))
-                                    .isEqualTo("site3-unavailable");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("17");
-                        });
+        assertPage(SERVICE_UNAVAILABLE, "site3-unavailable");
+    }
+
+    @Test
+    public void testSiteInheritsGlobalError() {
+        init(merged(siteUnavailable(page("site is down"))));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertPage(INTERNAL_SERVER_ERROR, "global-error");
+    }
+
+    @Test
+    public void testSiteTextSlotDropsDefaultFile() {
+        init(FallbackConfig.DEFAULTS.merge(siteUnavailable(page("we are down"))));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        // NOT the bundled fallback/unavailable.html; the whole DEFAULTS slot (file included) was replaced.
+        assertPage(SERVICE_UNAVAILABLE, "we are down");
+    }
+
+    @Test
+    public void testCustomContentType() {
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().text("{\"down\":true}").contentType("application/json").build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
     }
 
     @Test
     public void testOkPassesThrough() {
         init(merged(null));
         upstreamResponds(OK, "real-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.status()).isEqualTo(OK);
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("real-body");
-                        });
+        assertPassThrough(OK, "real-body");
     }
 
     @Test
     public void testNon5xxPassesThrough() {
         init(merged(null));
         upstreamResponds(NOT_FOUND, "real-404");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.status()).isEqualTo(NOT_FOUND);
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("real-404");
-                        });
+        assertPassThrough(NOT_FOUND, "real-404");
     }
 
     @Test
     public void testUnavailablePageFromClasspath() {
-        init(merged(FallbackConfig.builder()
-                        .unavailablePage("fallback/unavailable_page.html")
-                        .unavailableText("service is unavailable")
-                        .build()
-                )
-        );
+        init(merged(siteUnavailable(ResponseConfig.builder()
+                .file("fallback/unavailable_page.html")
+                .text("service is unavailable")
+                .build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>down</html>");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE))
-                                    .isEqualTo("text/html; charset=UTF-8");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("17");
-                        });
-    }
-
-    @Test
-    public void testUnavailablePageNotFoundFallsBackToGlobalText() {
-        init(merged(FallbackConfig.builder().unavailablePage("fallback/non_existent_page.html").build()));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("global-unavailable");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
-                        });
-    }
-
-    @Test
-    public void testUnavailablePageNotFoundFallsBackToSiteText() {
-        init(merged(FallbackConfig.builder()
-                        .unavailablePage("fallback/non_existent_page.html")
-                        .unavailableText("service unavailable")
-                        .build()
-                )
-        );
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("service unavailable");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("19");
-                        });
+        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
     }
 
     @Test
     public void testErrorPageFromClasspath() {
-        init(merged(FallbackConfig.builder()
-                        .errorPage("fallback/error_page.html")
-                        .errorText("internal server error")
-                        .build()
-                )
-        );
+        init(merged(siteError(ResponseConfig.builder()
+                .file("fallback/error_page.html")
+                .text("internal server error")
+                .build())));
         upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>error</html>");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
-                        });
+        assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
+    }
+
+    @Test
+    public void testMissingFileFallsBackToSlotText() {
+        init(merged(siteUnavailable(ResponseConfig.builder()
+                .file("fallback/non_existent_page.html")
+                .text("service unavailable")
+                .build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(SERVICE_UNAVAILABLE, "service unavailable");
     }
 
     @Test
     public void testUnavailablePageFromDiskFile(@TempDir Path tempDir) throws IOException {
-        Path page = tempDir.resolve("down.html");
-        Files.writeString(page, "<html>disk-down</html>");
+        Path pageFile = tempDir.resolve("down.html");
+        Files.writeString(pageFile, "<html>disk-down</html>");
 
-        init(merged(FallbackConfig.builder()
-                        .unavailablePage(page.toAbsolutePath().toString())
-                        .unavailableText("service is unavailable")
-                        .build()
-                )
-        );
+        init(merged(siteUnavailable(ResponseConfig.builder()
+                .file(pageFile.toAbsolutePath().toString())
+                .text("service is unavailable")
+                .build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>disk-down</html>");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("22");
-                        });
+        assertPage(SERVICE_UNAVAILABLE, "<html>disk-down</html>");
     }
 
     @Test
-    public void testSiteUnavailableText() {
-        init(merged(FallbackConfig.builder().unavailableText("service is unavailable").build()));
+    public void testUnavailableRedirectDefaults302() {
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().location("https://status.example/").build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("service is unavailable");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("22");
-                        });
+        assertRedirect(FOUND, "https://status.example/");
     }
 
     @Test
-    public void testSiteErrorText() {
-        init(merged(FallbackConfig.builder().errorText("internal server error").build()));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("internal server error");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("21");
-                        });
-    }
-
-    @Test
-    public void testUnavailablePageBeatsText() {
-        init(
-                merged(
-                        FallbackConfig.builder()
-                                .unavailablePage("fallback/unavailable_page.html")
-                                .unavailableText("service is unavailable")
-                                .build()));
+    public void testUnavailableRedirectHonorsExplicitStatus() {
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().location("https://status.example/").status(301).build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>down</html>");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("17");
-                        });
+        assertRedirect(MOVED_PERMANENTLY, "https://status.example/");
     }
 
     @Test
-    public void testErrorPageBeatsText() {
-        init(
-                merged(
-                        FallbackConfig.builder()
-                                .errorPage("fallback/error_page.html")
-                                .errorText("internal server error")
-                                .build()));
+    public void testErrorPermanentRedirect() {
+        init(merged(siteError(
+                ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
         upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("<html>error</html>");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("18");
-                        });
+        assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
     }
 
     @Test
-    public void testSiteInheritsGlobalError() {
-        init(merged(FallbackConfig.builder().unavailableText("service is unavailable").build()));
+    public void testErrorTemporaryRedirect() {
+        init(merged(siteError(
+                ResponseConfig.builder().temporaryRedirect("https://elsewhere.example/").build())));
         upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        response -> {
-                            assertThat(response.content().toString(StandardCharsets.UTF_8)).isEqualTo("global-error");
-                            assertThat(response.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("12");
-                        });
+        assertRedirect(TEMPORARY_REDIRECT, "https://elsewhere.example/");
+    }
+
+    @Test
+    public void testSitePageReplacesGlobalRedirect() {
+        FallbackConfig globalRedirect =
+                FallbackConfig.builder()
+                        .unavailableResponse(
+                                ResponseConfig.builder().permanentRedirect("http://origin.example/data").build())
+                        .build();
+        FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
+
+        init(FallbackConfig.DEFAULTS.merge(globalRedirect).merge(site));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        // page served, no Location header logic involved; the global redirect is gone entirely
+        assertPage(SERVICE_UNAVAILABLE, "SITE3: down for maintenance");
+    }
+
+    @Test
+    public void testEmptySlotServesLastResortText() {
+        init(merged(siteUnavailable(ResponseConfig.builder().build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(SERVICE_UNAVAILABLE, "Unknown problem occurred");
     }
 }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -4,6 +4,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.MOVED_PERMANENTLY;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_IMPLEMENTED;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.PERMANENT_REDIRECT;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
@@ -140,7 +141,10 @@ public class FallbackTest {
 
     @Test
     public void partialConfigParsesSparse() {
-        FallbackConfig cfg = parse("unavailableResponse:\n  text: site2 down\n");
+        FallbackConfig cfg = parse("""
+            unavailableResponse:
+                text: site2 down
+            """);
 
         assertThat(cfg.unavailableResponse()).isNotNull();
         assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
@@ -219,6 +223,15 @@ public class FallbackTest {
         assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
     }
 
+
+    @Test
+    public void testPageStatusOverrideIsIgnored() {
+        init(merged(siteError(
+                ResponseConfig.builder().text("err page").status(501).build())));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertPage(INTERNAL_SERVER_ERROR, "err page");
+    }
+
     @Test
     public void testOkPassesThrough() {
         init(merged(null));
@@ -231,6 +244,13 @@ public class FallbackTest {
         init(merged(null));
         upstreamResponds(NOT_FOUND, "real-404");
         assertPassThrough(NOT_FOUND, "real-404");
+    }
+
+    @Test
+    public void testOtherServerErrorStatusesPassThroughUnmodified() {
+        init(merged(null));
+        upstreamResponds(NOT_IMPLEMENTED, "real-501");
+        assertPassThrough(NOT_IMPLEMENTED, "real-501");
     }
 
     @Test
@@ -290,6 +310,14 @@ public class FallbackTest {
                 ResponseConfig.builder().location("https://status.example/").status(301).build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
         assertRedirect(MOVED_PERMANENTLY, "https://status.example/");
+    }
+
+    @Test
+    public void testUnavailablePermanentRedirect() {
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
     }
 
     @Test

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -269,39 +270,56 @@ public class FallbackTest {
     @Test
     public void testUnavailablePageFromClasspath() {
         init(merged(siteUnavailable(
+                ResponseConfig.builder().file("classpath:fallback/unavailable_page.html").build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
+    }
+
+    @Test
+    public void testFileAndTextTogetherRejected() {
+        assertThatThrownBy(() -> ResponseConfig.builder()
+                .file("classpath:fallback/unavailable_page.html")
+                .text("service is unavailable")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not both");
+    }
+
+    @Test
+    public void testErrorPageFromClasspath() {
+        init(merged(siteError(
+                ResponseConfig.builder().file("classpath:fallback/error_page.html").build())));
+        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+        assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
+    }
+
+    @Test
+    public void testMissingFileHardFails() {
+        FallbackConfig cfg = merged(siteUnavailable(
+                ResponseConfig.builder().file("classpath:fallback/non_existent_page.html").build()));
+        assertThatThrownBy(() -> new FallbackHandler(cfg))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageContaining("non_existent_page.html");
+    }
+
+    @Test
+    public void testSchemelessResolvesViaClasspath() {
+        // no scheme, not on disk -> falls through to the classpath resource
+        init(merged(siteUnavailable(
                 ResponseConfig.builder().file("fallback/unavailable_page.html").build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
         assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
     }
 
     @Test
-    public void testUnavailablePageFromClasspathWithText() {
-        init(merged(siteUnavailable(ResponseConfig.builder()
-                .file("fallback/unavailable_page.html")
-                .text("service is unavailable")
-                .build())));
+    public void testSchemelessPrefersFilesystem(@TempDir Path tempDir) throws IOException {
+        Path pageFile = tempDir.resolve("down.html");
+        Files.writeString(pageFile, "<html>disk-first</html>");
+        // no scheme, exists on disk -> filesystem wins over any classpath resource
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().file(pageFile.toAbsolutePath().toString()).build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
-    }
-
-    @Test
-    public void testErrorPageFromClasspath() {
-        init(merged(siteError(ResponseConfig.builder()
-                .file("fallback/error_page.html")
-                .text("internal server error")
-                .build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
-    }
-
-    @Test
-    public void testMissingFileFallsBackToSlotText() {
-        init(merged(siteUnavailable(ResponseConfig.builder()
-                .file("fallback/non_existent_page.html")
-                .text("service unavailable")
-                .build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "service unavailable");
+        assertPage(SERVICE_UNAVAILABLE, "<html>disk-first</html>");
     }
 
     @Test
@@ -309,10 +327,8 @@ public class FallbackTest {
         Path pageFile = tempDir.resolve("down.html");
         Files.writeString(pageFile, "<html>disk-down</html>");
 
-        init(merged(siteUnavailable(ResponseConfig.builder()
-                .file(pageFile.toAbsolutePath().toString())
-                .text("service is unavailable")
-                .build())));
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().file("file:" + pageFile.toAbsolutePath()).build())));
         upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
         assertPage(SERVICE_UNAVAILABLE, "<html>disk-down</html>");
     }

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -254,9 +254,17 @@ public class FallbackTest {
         upstreamResponds(NOT_FOUND, "real-404");
         assertPassThrough(NOT_FOUND, "real-404");
     }
-
+    
     @Test
     public void testUnavailablePageFromClasspath() {
+        init(merged(siteUnavailable(
+                ResponseConfig.builder().file("fallback/unavailable_page.html").build())));
+        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
+    }
+
+    @Test
+    public void testUnavailablePageFromClasspathWithText() {
         init(merged(siteUnavailable(ResponseConfig.builder()
                 .file("fallback/unavailable_page.html")
                 .text("service is unavailable")

--- a/src/test/java/org/sensepitch/edge/FallbackTest.java
+++ b/src/test/java/org/sensepitch/edge/FallbackTest.java
@@ -22,13 +22,11 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,322 +39,352 @@ import org.yaml.snakeyaml.nodes.Node;
  */
 public class FallbackTest {
 
-    private static final String HTML = "text/html; charset=UTF-8";
+  private static final String HTML = "text/html; charset=UTF-8";
 
-    private static final FallbackConfig GLOBAL =
-            FallbackConfig.builder()
-                    .unavailableResponse(page("global-unavailable"))
-                    .errorResponse(page("global-error"))
-                    .build();
+  private static final FallbackConfig GLOBAL =
+      FallbackConfig.builder()
+          .unavailableResponse(page("global-unavailable"))
+          .errorResponse(page("global-error"))
+          .build();
 
-    private EmbeddedChannel channel;
-    private Object messageWritten;
+  private EmbeddedChannel channel;
+  private Object messageWritten;
 
-    private static ResponseConfig page(String text) {
-        return ResponseConfig.builder().text(text).build();
+  private static ResponseConfig page(String text) {
+    return ResponseConfig.builder().text(text).build();
+  }
+
+  private static FallbackConfig siteUnavailable(ResponseConfig r) {
+    return FallbackConfig.builder().unavailableResponse(r).build();
+  }
+
+  private static FallbackConfig siteError(ResponseConfig r) {
+    return FallbackConfig.builder().errorResponse(r).build();
+  }
+
+  private static FallbackConfig merged(FallbackConfig site) {
+    return FallbackConfig.DEFAULTS.merge(GLOBAL).merge(site);
+  }
+
+  private void init(FallbackConfig cfg) {
+    ChannelOutboundHandler capture =
+        new ChannelOutboundHandlerAdapter() {
+          @Override
+          public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            messageWritten = msg;
+            ctx.write(msg, promise);
+          }
+        };
+    channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
+  }
+
+  private void upstreamResponds(HttpResponseStatus status, String body) {
+    messageWritten = null;
+    channel.writeOutbound(
+        new DefaultFullHttpResponse(
+            HTTP_1_1, status, Unpooled.copiedBuffer(body, StandardCharsets.UTF_8)));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (channel != null) {
+      channel.finishAndReleaseAll();
     }
+  }
 
-    private static FallbackConfig siteUnavailable(ResponseConfig r) {
-        return FallbackConfig.builder().unavailableResponse(r).build();
-    }
+  private void assertPage(HttpResponseStatus status, String body, String contentType) {
+    assertThat(messageWritten)
+        .isInstanceOfSatisfying(
+            FullHttpResponse.class,
+            r -> {
+              assertThat(r.status()).isEqualTo(status);
+              assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
+              assertThat(r.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(contentType);
+              assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH))
+                  .isEqualTo(String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
+            });
+  }
 
-    private static FallbackConfig siteError(ResponseConfig r) {
-        return FallbackConfig.builder().errorResponse(r).build();
-    }
+  private void assertPage(HttpResponseStatus status, String body) {
+    assertPage(status, body, HTML);
+  }
 
-    private static FallbackConfig merged(FallbackConfig site) {
-        return FallbackConfig.DEFAULTS.merge(GLOBAL).merge(site);
-    }
+  private void assertRedirect(HttpResponseStatus status, String location) {
+    assertThat(messageWritten)
+        .isInstanceOfSatisfying(
+            FullHttpResponse.class,
+            r -> {
+              assertThat(r.status()).isEqualTo(status);
+              assertThat(r.headers().get(HttpHeaderNames.LOCATION)).isEqualTo(location);
+              assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
+              assertThat(r.content().readableBytes()).isZero();
+            });
+  }
 
-    private void init(FallbackConfig cfg) {
-        ChannelOutboundHandler capture =
-                new ChannelOutboundHandlerAdapter() {
-                    @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                        messageWritten = msg;
-                        ctx.write(msg, promise);
-                    }
-                };
-        channel = new EmbeddedChannel(capture, new FallbackHandler(cfg));
-    }
+  private void assertPassThrough(HttpResponseStatus status, String body) {
+    assertThat(messageWritten)
+        .isInstanceOfSatisfying(
+            FullHttpResponse.class,
+            r -> {
+              assertThat(r.status()).isEqualTo(status);
+              assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
+            });
+  }
 
-    private void upstreamResponds(HttpResponseStatus status, String body) {
-        messageWritten = null;
-        channel.writeOutbound(
-                new DefaultFullHttpResponse(
-                        HTTP_1_1, status, Unpooled.copiedBuffer(body, StandardCharsets.UTF_8)));
-    }
+  private static FallbackConfig parse(String yaml) {
+    Node root = new Yaml().compose(new StringReader(yaml));
+    return RecordConstructor.construct(FallbackConfig.class, root);
+  }
 
-    @AfterEach
-    void tearDown() {
-        if (channel != null) {
-            channel.finishAndReleaseAll();
-        }
-    }
+  @Test
+  public void partialConfigParsesSparse() {
+    FallbackConfig cfg = parse("unavailableResponse:\n  text: site2 down\n");
 
-    private void assertPage(HttpResponseStatus status, String body, String contentType) {
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        r -> {
-                            assertThat(r.status()).isEqualTo(status);
-                            assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
-                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(contentType);
-                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH))
-                                    .isEqualTo(String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
-                        });
-    }
+    assertThat(cfg.unavailableResponse()).isNotNull();
+    assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
+    assertThat(cfg.unavailableResponse().file()).isNull();
+    assertThat(cfg.unavailableResponse().permanentRedirect()).isNull();
+    assertThat(cfg.unavailableResponse().temporaryRedirect()).isNull();
+    assertThat(cfg.unavailableResponse().location()).isNull();
+    assertThat(cfg.unavailableResponse().contentType()).isNull();
+    assertThat(cfg.unavailableResponse().status()).isEqualTo(0);
+    assertThat(cfg.errorResponse())
+        .as("slot not present in YAML must stay null, not be seeded from defaults")
+        .isNull();
+  }
 
-    private void assertPage(HttpResponseStatus status, String body) {
-        assertPage(status, body, HTML);
-    }
+  @Test
+  public void siteOverrideDoesNotBeatGlobal() {
+    FallbackConfig global = parse("errorResponse:\n  text: global error\n");
+    FallbackConfig site = parse("unavailableResponse:\n  text: site2 down\n");
 
-    private void assertRedirect(HttpResponseStatus status, String location) {
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        r -> {
-                            assertThat(r.status()).isEqualTo(status);
-                            assertThat(r.headers().get(HttpHeaderNames.LOCATION)).isEqualTo(location);
-                            assertThat(r.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("0");
-                            assertThat(r.content().readableBytes()).isZero();
-                        });
-    }
+    FallbackConfig resolved = FallbackConfig.DEFAULTS.merge(global).merge(site);
 
-    private void assertPassThrough(HttpResponseStatus status, String body) {
-        assertThat(messageWritten)
-                .isInstanceOfSatisfying(
-                        FullHttpResponse.class,
-                        r -> {
-                            assertThat(r.status()).isEqualTo(status);
-                            assertThat(r.content().toString(StandardCharsets.UTF_8)).isEqualTo(body);
-                        });
-    }
+    assertThat(resolved.unavailableResponse().text())
+        .as("site override applies")
+        .isEqualTo("site2 down");
+    assertThat(resolved.errorResponse().text())
+        .as("global error slot must survive: the site never overrode it")
+        .isEqualTo("global error");
+  }
 
-    private static FallbackConfig parse(String yaml) {
-        Node root = new Yaml().compose(new StringReader(yaml));
-        return RecordConstructor.construct(FallbackConfig.class, root);
-    }
+  @Test
+  public void redirectAndPageInSameResponseFailsToParse() {
+    assertThatThrownBy(() -> parse("unavailableResponse:\n  location: /elsewhere\n  text: hi\n"))
+        .rootCause()
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
-    @Test
-    public void partialConfigParsesSparse() {
-        FallbackConfig cfg = parse("unavailableResponse:\n  text: site2 down\n");
+  @Test
+  public void redirectWithNon3xxStatusFails() {
+    assertThatThrownBy(() -> ResponseConfig.builder().location("/elsewhere").status(200).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
-        assertThat(cfg.unavailableResponse()).isNotNull();
-        assertThat(cfg.unavailableResponse().text()).isEqualTo("site2 down");
-        assertThat(cfg.unavailableResponse().file()).isNull();
-        assertThat(cfg.unavailableResponse().permanentRedirect()).isNull();
-        assertThat(cfg.unavailableResponse().temporaryRedirect()).isNull();
-        assertThat(cfg.unavailableResponse().location()).isNull();
-        assertThat(cfg.unavailableResponse().contentType()).isNull();
-        assertThat(cfg.unavailableResponse().status()).isEqualTo(0);
-        assertThat(cfg.errorResponse())
-                .as("slot not present in YAML must stay null, not be seeded from defaults")
-                .isNull();
-    }
+  @Test
+  public void testGlobalUnavailable() {
+    init(merged(null));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "global-unavailable");
+  }
 
-    @Test
-    public void siteOverrideDoesNotBeatGlobal() {
-        FallbackConfig global = parse("errorResponse:\n  text: global error\n");
-        FallbackConfig site = parse("unavailableResponse:\n  text: site2 down\n");
+  @Test
+  public void testGlobalError() {
+    init(merged(null));
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertPage(INTERNAL_SERVER_ERROR, "global-error");
+  }
 
-        FallbackConfig resolved = FallbackConfig.DEFAULTS.merge(global).merge(site);
+  @Test
+  public void testSiteOverridesUnavailable() {
+    init(merged(siteUnavailable(page("site3-unavailable"))));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "site3-unavailable");
+  }
 
-        assertThat(resolved.unavailableResponse().text()).as("site override applies").isEqualTo("site2 down");
-        assertThat(resolved.errorResponse().text())
-                .as("global error slot must survive: the site never overrode it")
-                .isEqualTo("global error");
-    }
+  @Test
+  public void testSiteInheritsGlobalError() {
+    init(merged(siteUnavailable(page("site is down"))));
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertPage(INTERNAL_SERVER_ERROR, "global-error");
+  }
 
-    @Test
-    public void redirectAndPageInSameResponseFailsToParse() {
-        assertThatThrownBy(() -> parse("unavailableResponse:\n  location: /elsewhere\n  text: hi\n"))
-                .rootCause()
-                .isInstanceOf(IllegalArgumentException.class);
-    }
+  @Test
+  public void testSiteTextSlotDropsDefaultFile() {
+    init(FallbackConfig.DEFAULTS.merge(siteUnavailable(page("we are down"))));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    // NOT the bundled fallback/unavailable.html; the whole DEFAULTS slot (file included) was
+    // replaced.
+    assertPage(SERVICE_UNAVAILABLE, "we are down");
+  }
 
-    @Test
-    public void redirectWithNon3xxStatusFails() {
-        assertThatThrownBy(() ->
-                ResponseConfig.builder().location("/elsewhere").status(200).build())
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void testGlobalUnavailable() {
-        init(merged(null));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "global-unavailable");
-    }
-
-    @Test
-    public void testGlobalError() {
-        init(merged(null));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "global-error");
-    }
-
-    @Test
-    public void testSiteOverridesUnavailable() {
-        init(merged(siteUnavailable(page("site3-unavailable"))));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "site3-unavailable");
-    }
-
-    @Test
-    public void testSiteInheritsGlobalError() {
-        init(merged(siteUnavailable(page("site is down"))));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "global-error");
-    }
-
-    @Test
-    public void testSiteTextSlotDropsDefaultFile() {
-        init(FallbackConfig.DEFAULTS.merge(siteUnavailable(page("we are down"))));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        // NOT the bundled fallback/unavailable.html; the whole DEFAULTS slot (file included) was replaced.
-        assertPage(SERVICE_UNAVAILABLE, "we are down");
-    }
-
-    @Test
-    public void testPageHonorsExplicitStatus() {
-        init(merged(siteUnavailable(
+  @Test
+  public void testPageHonorsExplicitStatus() {
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().text("down for maintenance").status(200).build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(OK, "down for maintenance");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(OK, "down for maintenance");
+  }
 
-    @Test
-    public void testPageWithoutStatusKeepsOriginStatus() {
-        init(merged(siteUnavailable(page("still down"))));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "still down");
-    }
+  @Test
+  public void testPageWithoutStatusKeepsOriginStatus() {
+    init(merged(siteUnavailable(page("still down"))));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "still down");
+  }
 
-    @Test
-    public void testCustomContentType() {
-        init(merged(siteUnavailable(
-                ResponseConfig.builder().text("{\"down\":true}").contentType("application/json").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
-    }
+  @Test
+  public void testCustomContentType() {
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .text("{\"down\":true}")
+                    .contentType("application/json")
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "{\"down\":true}", "application/json");
+  }
 
-    @Test
-    public void testOkPassesThrough() {
-        init(merged(null));
-        upstreamResponds(OK, "real-body");
-        assertPassThrough(OK, "real-body");
-    }
+  @Test
+  public void testOkPassesThrough() {
+    init(merged(null));
+    upstreamResponds(OK, "real-body");
+    assertPassThrough(OK, "real-body");
+  }
 
-    @Test
-    public void testNon5xxPassesThrough() {
-        init(merged(null));
-        upstreamResponds(NOT_FOUND, "real-404");
-        assertPassThrough(NOT_FOUND, "real-404");
-    }
-    
-    @Test
-    public void testUnavailablePageFromClasspath() {
-        init(merged(siteUnavailable(
+  @Test
+  public void testNon5xxPassesThrough() {
+    init(merged(null));
+    upstreamResponds(NOT_FOUND, "real-404");
+    assertPassThrough(NOT_FOUND, "real-404");
+  }
+
+  @Test
+  public void testUnavailablePageFromClasspath() {
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().file("fallback/unavailable_page.html").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
+  }
 
-    @Test
-    public void testUnavailablePageFromClasspathWithText() {
-        init(merged(siteUnavailable(ResponseConfig.builder()
-                .file("fallback/unavailable_page.html")
-                .text("service is unavailable")
-                .build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
-    }
+  @Test
+  public void testUnavailablePageFromClasspathWithText() {
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .file("fallback/unavailable_page.html")
+                    .text("service is unavailable")
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>down</html>");
+  }
 
-    @Test
-    public void testErrorPageFromClasspath() {
-        init(merged(siteError(ResponseConfig.builder()
-                .file("fallback/error_page.html")
-                .text("internal server error")
-                .build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
-    }
+  @Test
+  public void testErrorPageFromClasspath() {
+    init(
+        merged(
+            siteError(
+                ResponseConfig.builder()
+                    .file("fallback/error_page.html")
+                    .text("internal server error")
+                    .build())));
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertPage(INTERNAL_SERVER_ERROR, "<html>error</html>");
+  }
 
-    @Test
-    public void testMissingFileFallsBackToSlotText() {
-        init(merged(siteUnavailable(ResponseConfig.builder()
-                .file("fallback/non_existent_page.html")
-                .text("service unavailable")
-                .build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "service unavailable");
-    }
+  @Test
+  public void testMissingFileFallsBackToSlotText() {
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .file("fallback/non_existent_page.html")
+                    .text("service unavailable")
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "service unavailable");
+  }
 
-    @Test
-    public void testUnavailablePageFromDiskFile(@TempDir Path tempDir) throws IOException {
-        Path pageFile = tempDir.resolve("down.html");
-        Files.writeString(pageFile, "<html>disk-down</html>");
+  @Test
+  public void testUnavailablePageFromDiskFile(@TempDir Path tempDir) throws IOException {
+    Path pageFile = tempDir.resolve("down.html");
+    Files.writeString(pageFile, "<html>disk-down</html>");
 
-        init(merged(siteUnavailable(ResponseConfig.builder()
-                .file(pageFile.toAbsolutePath().toString())
-                .text("service is unavailable")
-                .build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "<html>disk-down</html>");
-    }
+    init(
+        merged(
+            siteUnavailable(
+                ResponseConfig.builder()
+                    .file(pageFile.toAbsolutePath().toString())
+                    .text("service is unavailable")
+                    .build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "<html>disk-down</html>");
+  }
 
-    @Test
-    public void testUnavailableRedirectDefaults302() {
-        init(merged(siteUnavailable(
-                ResponseConfig.builder().location("https://status.example/").build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertRedirect(FOUND, "https://status.example/");
-    }
+  @Test
+  public void testUnavailableRedirectDefaults302() {
+    init(
+        merged(
+            siteUnavailable(ResponseConfig.builder().location("https://status.example/").build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertRedirect(FOUND, "https://status.example/");
+  }
 
-    @Test
-    public void testUnavailableRedirectHonorsExplicitStatus() {
-        init(merged(siteUnavailable(
+  @Test
+  public void testUnavailableRedirectHonorsExplicitStatus() {
+    init(
+        merged(
+            siteUnavailable(
                 ResponseConfig.builder().location("https://status.example/").status(301).build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertRedirect(MOVED_PERMANENTLY, "https://status.example/");
-    }
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertRedirect(MOVED_PERMANENTLY, "https://status.example/");
+  }
 
-    @Test
-    public void testErrorPermanentRedirect() {
-        init(merged(siteError(
+  @Test
+  public void testErrorPermanentRedirect() {
+    init(
+        merged(
+            siteError(
                 ResponseConfig.builder().permanentRedirect("https://elsewhere.example/").build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
-    }
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertRedirect(PERMANENT_REDIRECT, "https://elsewhere.example/");
+  }
 
-    @Test
-    public void testErrorTemporaryRedirect() {
-        init(merged(siteError(
+  @Test
+  public void testErrorTemporaryRedirect() {
+    init(
+        merged(
+            siteError(
                 ResponseConfig.builder().temporaryRedirect("https://elsewhere.example/").build())));
-        upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
-        assertRedirect(TEMPORARY_REDIRECT, "https://elsewhere.example/");
-    }
+    upstreamResponds(INTERNAL_SERVER_ERROR, "ignored-origin-body");
+    assertRedirect(TEMPORARY_REDIRECT, "https://elsewhere.example/");
+  }
 
-    @Test
-    public void testSitePageReplacesGlobalRedirect() {
-        FallbackConfig globalRedirect =
-                FallbackConfig.builder()
-                        .unavailableResponse(
-                                ResponseConfig.builder().permanentRedirect("http://origin.example/data").build())
-                        .build();
-        FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
+  @Test
+  public void testSitePageReplacesGlobalRedirect() {
+    FallbackConfig globalRedirect =
+        FallbackConfig.builder()
+            .unavailableResponse(
+                ResponseConfig.builder().permanentRedirect("http://origin.example/data").build())
+            .build();
+    FallbackConfig site = siteUnavailable(page("SITE3: down for maintenance"));
 
-        init(FallbackConfig.DEFAULTS.merge(globalRedirect).merge(site));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        // page served, no Location header logic involved; the global redirect is gone entirely
-        assertPage(SERVICE_UNAVAILABLE, "SITE3: down for maintenance");
-    }
+    init(FallbackConfig.DEFAULTS.merge(globalRedirect).merge(site));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    // page served, no Location header logic involved; the global redirect is gone entirely
+    assertPage(SERVICE_UNAVAILABLE, "SITE3: down for maintenance");
+  }
 
-    @Test
-    public void testEmptySlotServesLastResortText() {
-        init(merged(siteUnavailable(ResponseConfig.builder().build())));
-        upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
-        assertPage(SERVICE_UNAVAILABLE, "Unknown problem occurred");
-    }
+  @Test
+  public void testEmptySlotServesLastResortText() {
+    init(merged(siteUnavailable(ResponseConfig.builder().build())));
+    upstreamResponds(SERVICE_UNAVAILABLE, "ignored-origin-body");
+    assertPage(SERVICE_UNAVAILABLE, "Unknown problem occurred");
+  }
 }

--- a/src/test/java/org/sensepitch/edge/ProtectionBypassTest.java
+++ b/src/test/java/org/sensepitch/edge/ProtectionBypassTest.java
@@ -40,8 +40,7 @@ public class ProtectionBypassTest {
         ProtectionConfig.builder()
             .bypass(new ProtectionBypassConfig(List.of(ACCESS_URI), null))
             .cookieGates(
-                List.of(
-                    CookieGateConfig.builder().name(COOKIE_NAME).accessUri(ACCESS_URI).build()))
+                List.of(CookieGateConfig.builder().name(COOKIE_NAME).accessUri(ACCESS_URI).build()))
             .build();
     Supplier<ChannelHandler> supplier = Protection.handlerSupplier(protection);
     assertThat(supplier).isNotNull();

--- a/src/test/java/org/sensepitch/edge/ProtectionOrderTest.java
+++ b/src/test/java/org/sensepitch/edge/ProtectionOrderTest.java
@@ -41,7 +41,8 @@ public class ProtectionOrderTest {
     ProtectionConfig protection =
         ProtectionConfig.builder()
             .deflector(deflectorConfig())
-            .cookieGates(List.of(CookieGateConfig.builder().name(COOKIE_NAME).accessUri(ACCESS_URI).build()))
+            .cookieGates(
+                List.of(CookieGateConfig.builder().name(COOKIE_NAME).accessUri(ACCESS_URI).build()))
             .build();
     Supplier<ChannelHandler> supplier = Protection.handlerSupplier(protection);
     assertThat(supplier).isNotNull();

--- a/src/test/java/org/sensepitch/edge/ProxyConstructBDDTest.java
+++ b/src/test/java/org/sensepitch/edge/ProxyConstructBDDTest.java
@@ -135,7 +135,7 @@ class ProxyConstructBDDTest {
                             .build())
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("redirect and a page");
+        .hasMessageContaining("response should be one of");
   }
 
   static class Steps extends ExtendableSteps<Steps> {}

--- a/src/test/java/org/sensepitch/edge/ProxyConstructBDDTest.java
+++ b/src/test/java/org/sensepitch/edge/ProxyConstructBDDTest.java
@@ -1,6 +1,7 @@
 package org.sensepitch.edge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 import net.serenitybdd.annotations.Step;
@@ -120,6 +121,21 @@ class ProxyConstructBDDTest {
             .metrics(MetricsConfig.builder().enable(false).build())
             .build();
     steps.given_the_configuration(config).then_expect_initialized_without_exception();
+  }
+
+  @Test
+  void testResponseConfigMixingTextAndLocationFailsParsing() {
+    assertThatThrownBy(
+            () ->
+                SiteConfig.builder()
+                    .response(
+                        ResponseConfig.builder()
+                            .text("demo")
+                            .location("https://elsewhere.example/")
+                            .build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("redirect and a page");
   }
 
   static class Steps extends ExtendableSteps<Steps> {}

--- a/src/test/resources/fallback/error_page.html
+++ b/src/test/resources/fallback/error_page.html
@@ -1,0 +1,1 @@
+<html>error</html>

--- a/src/test/resources/fallback/unavailable_page.html
+++ b/src/test/resources/fallback/unavailable_page.html
@@ -1,0 +1,1 @@
+<html>down</html>


### PR DESCRIPTION
Replaces upstream `503` and `500` responses with an operator-configured fallback page, text, or redirect, so users see a friendly page instead of the origin's raw error.

### What it does
- `503` → unavailable response, `500` → error response; every other status passes through untouched
- Each response slot is one of two kinds:
  - **page**: inline `text` **or** a `file` (never both), with optional `contentType` and optional `status`
  - **redirect**: `location`, with optional `status`
  - a slot with neither a `location` nor a page body is rejected
- Page `status` is optional: unset means "keep the origin status"; set means the fallback overrides it.
- Page file resolution: `classpath:...` or `file:...` picks that source explicitly; a schemeless location is tried on the filesystem first, then on the classpath. A page body that cannot be read fails construction instead of silently degrading. Bodies are read once, at `Fallback` construction, and shared by every handler.
- Built-in defaults are the bundled `classpath:fallback/unavailable.html` and `classpath:fallback/error.html`.
- Global fallback config, overridable per site. Merge is **per response slot** (`DEFAULTS → global → site`): a site that sets `unavailableResponse` replaces that whole slot, `file` and `contentType` included, but inherits `errorResponse` untouched.
- Works for both aggregated `FullHttpResponse` and streamed responses from real upstreams. On the streamed path the origin body chunks are dropped and released after the head is swapped, and the suppression flag resets at `LastHttpContent` so the next response on a keep-alive connection is unaffected. `Connection` is preserved; `Content-Type`/`Content-Length` are set for pages, `Location` and `Content-Length: 0` for redirects.

### Config

```yaml
fallback:
  unavailableResponse:
    text: "We'll be right back"
  errorResponse:
    file: "fallback/error.html"        # disk first, then classpath
sites:
  shop.example.com:
    fallback:
      unavailableResponse:
        file: "classpath:shop-maintenance.html"
        contentType: "text/html; charset=UTF-8"
  status.example.com:
    fallback:
      unavailableResponse:
        location: "https://status.example.com"
        status: 307                    # omit for 302
```

### Test
Handler-level EmbeddedChannel tests: FallbackTest (aggregated path) and FallbackStreamingTest (streamed path), covering page/file/redirect responses, per-slot merge, mixed-kind rejection, and origin-body suppression on the streamed path.